### PR TITLE
feat: add graceful error handling with 404/500 pages and error boundary

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect } from 'react';
+import { CircleDot } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('[App Error]', error);
+  }, [error]);
+
+  return (
+    <main className="min-h-screen bg-background flex flex-col items-center justify-center px-4 text-center">
+      <CircleDot className="h-12 w-12 text-destructive mb-6" />
+      <h1 className="text-2xl font-bold text-foreground mb-3">Something went wrong</h1>
+      <p className="text-muted-foreground mb-8 max-w-sm">
+        {error.message || 'An unexpected error occurred. Please try again.'}
+      </p>
+      <div className="flex gap-3">
+        <Button onClick={reset}>Try again</Button>
+        <Button variant="outline" asChild>
+          <a href="/">Go home</a>
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+import { CircleDot } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export default function NotFound() {
+  return (
+    <main className="min-h-screen bg-background flex flex-col items-center justify-center px-4 text-center">
+      <CircleDot className="h-12 w-12 text-primary mb-6" />
+      <h1 className="text-6xl font-bold text-foreground mb-2">404</h1>
+      <h2 className="text-2xl font-semibold text-foreground mb-3">Page not found</h2>
+      <p className="text-muted-foreground mb-8 max-w-sm">
+        This page doesn't exist or may have been moved.
+      </p>
+      <Button asChild>
+        <Link href="/">Go home</Link>
+      </Button>
+    </main>
+  );
+}

--- a/components/error-fallback.tsx
+++ b/components/error-fallback.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+
+interface ErrorFallbackProps {
+  error: Error;
+  resetErrorBoundary: () => void;
+}
+
+export function ErrorFallback({ error, resetErrorBoundary }: ErrorFallbackProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 px-4 text-center rounded-lg border border-destructive/20 bg-destructive/5">
+      <p className="text-sm font-semibold text-destructive mb-1">Failed to load</p>
+      <p className="text-xs text-muted-foreground mb-4 max-w-xs">{error.message}</p>
+      <Button size="sm" variant="outline" onClick={resetErrorBoundary}>
+        Retry
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
- Add app/error.tsx: global error boundary with reset + home fallback, logs errors to console
- Add app/not-found.tsx: branded 404 page matching platform design
- Add components/error-fallback.tsx: reusable ErrorFallback for react-error-boundary wrappers

Closes #21 