### PR TITLE
fix(contract): enforce configurable circle member cap

### DIFF
--- a/contracts/ajo-circle/src/lib.rs
+++ b/contracts/ajo-circle/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, Env, Address, Map, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Map, Vec};
+
+const MAX_MEMBERS: u32 = 50;
+const HARD_CAP: u32 = 100;
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -16,6 +19,7 @@ pub enum AjoError {
     AlreadyVoted = 9,
     CircleNotActive = 10,
     CircleAlreadyDissolved = 11,
+    CircleAtCapacity = 12,
 }
 
 #[contracttype]
@@ -27,6 +31,7 @@ pub struct CircleData {
     pub max_rounds: u32,
     pub current_round: u32,
     pub member_count: u32,
+    pub max_members: u32,
 }
 
 #[contracttype]
@@ -80,10 +85,22 @@ impl AjoCircle {
         contribution_amount: i128,
         frequency_days: u32,
         max_rounds: u32,
+        max_members: u32,
     ) -> Result<(), AjoError> {
         organizer.require_auth();
 
-        if contribution_amount <= 0 || frequency_days == 0 || max_rounds == 0 {
+        let configured_max_members = if max_members == 0 {
+            MAX_MEMBERS
+        } else {
+            max_members
+        };
+
+        if contribution_amount <= 0
+            || frequency_days == 0
+            || max_rounds == 0
+            || configured_max_members == 0
+            || configured_max_members > HARD_CAP
+        {
             return Err(AjoError::InvalidInput);
         }
 
@@ -94,6 +111,7 @@ impl AjoCircle {
             max_rounds,
             current_round: 1,
             member_count: 1,
+            max_members: configured_max_members,
         };
 
         env.storage().instance().set(&DataKey::Circle, &circle_data);
@@ -115,11 +133,12 @@ impl AjoCircle {
         Ok(())
     }
 
-    /// Add a new member to the circle
-    pub fn add_member(env: Env, organizer: Address, new_member: Address) -> Result<(), AjoError> {
+    /// Join an existing circle as a new member
+    pub fn join_circle(env: Env, organizer: Address, new_member: Address) -> Result<(), AjoError> {
         organizer.require_auth();
 
-        let mut circle: CircleData = env.storage()
+        let mut circle: CircleData = env
+            .storage()
             .instance()
             .get(&DataKey::Circle)
             .ok_or(AjoError::NotFound)?;
@@ -128,13 +147,23 @@ impl AjoCircle {
             return Err(AjoError::Unauthorized);
         }
 
-        let mut members: Map<Address, MemberData> = env.storage()
+        let mut members: Map<Address, MemberData> = env
+            .storage()
             .instance()
             .get(&DataKey::Members)
             .ok_or(AjoError::NotFound)?;
 
         if members.contains_key(new_member.clone()) {
             return Err(AjoError::AlreadyExists);
+        }
+
+        let joined_member_count = circle
+            .member_count
+            .checked_sub(1)
+            .ok_or(AjoError::InvalidInput)?;
+
+        if joined_member_count >= circle.max_members {
+            return Err(AjoError::CircleAtCapacity);
         }
 
         members.set(
@@ -148,12 +177,20 @@ impl AjoCircle {
             },
         );
 
-        circle.member_count += 1;
+        circle.member_count = circle
+            .member_count
+            .checked_add(1)
+            .ok_or(AjoError::InvalidInput)?;
 
         env.storage().instance().set(&DataKey::Members, &members);
         env.storage().instance().set(&DataKey::Circle, &circle);
 
         Ok(())
+    }
+
+    /// Backward-compatible wrapper for joining the circle
+    pub fn add_member(env: Env, organizer: Address, new_member: Address) -> Result<(), AjoError> {
+        Self::join_circle(env, organizer, new_member)
     }
 
     /// Record a contribution from a member
@@ -164,7 +201,8 @@ impl AjoCircle {
             return Err(AjoError::InvalidInput);
         }
 
-        let mut members: Map<Address, MemberData> = env.storage()
+        let mut members: Map<Address, MemberData> = env
+            .storage()
             .instance()
             .get(&DataKey::Members)
             .ok_or(AjoError::NotFound)?;
@@ -185,12 +223,14 @@ impl AjoCircle {
     pub fn claim_payout(env: Env, member: Address) -> Result<i128, AjoError> {
         member.require_auth();
 
-        let circle: CircleData = env.storage()
+        let circle: CircleData = env
+            .storage()
             .instance()
             .get(&DataKey::Circle)
             .ok_or(AjoError::NotFound)?;
 
-        let mut members: Map<Address, MemberData> = env.storage()
+        let mut members: Map<Address, MemberData> = env
+            .storage()
             .instance()
             .get(&DataKey::Members)
             .ok_or(AjoError::NotFound)?;
@@ -222,7 +262,8 @@ impl AjoCircle {
             return Err(AjoError::InvalidInput);
         }
 
-        let mut members: Map<Address, MemberData> = env.storage()
+        let mut members: Map<Address, MemberData> = env
+            .storage()
             .instance()
             .get(&DataKey::Members)
             .ok_or(AjoError::NotFound)?;
@@ -256,7 +297,8 @@ impl AjoCircle {
 
     /// Get member balance and status
     pub fn get_member_balance(env: Env, member: Address) -> Result<MemberData, AjoError> {
-        let members: Map<Address, MemberData> = env.storage()
+        let members: Map<Address, MemberData> = env
+            .storage()
             .instance()
             .get(&DataKey::Members)
             .ok_or(AjoError::NotFound)?;
@@ -266,7 +308,8 @@ impl AjoCircle {
 
     /// Get all members
     pub fn get_members(env: Env) -> Result<Vec<MemberData>, AjoError> {
-        let members: Map<Address, MemberData> = env.storage()
+        let members: Map<Address, MemberData> = env
+            .storage()
             .instance()
             .get(&DataKey::Members)
             .ok_or(AjoError::NotFound)?;
@@ -295,12 +338,14 @@ impl AjoCircle {
         }
 
         // Circle must exist and be active
-        let circle: CircleData = env.storage()
+        let circle: CircleData = env
+            .storage()
             .instance()
             .get(&DataKey::Circle)
             .ok_or(AjoError::NotFound)?;
 
-        let status: CircleStatus = env.storage()
+        let status: CircleStatus = env
+            .storage()
             .instance()
             .get(&DataKey::CircleStatus)
             .unwrap_or(CircleStatus::Active);
@@ -312,7 +357,8 @@ impl AjoCircle {
         }
 
         // Caller must be a member or the organizer
-        let members: Map<Address, MemberData> = env.storage()
+        let members: Map<Address, MemberData> = env
+            .storage()
             .instance()
             .get(&DataKey::Members)
             .ok_or(AjoError::NotFound)?;
@@ -327,9 +373,15 @@ impl AjoCircle {
             threshold_mode,
         };
 
-        env.storage().instance().set(&DataKey::CircleStatus, &CircleStatus::VotingForDissolution);
-        env.storage().instance().set(&DataKey::DissolutionVote, &vote);
-        env.storage().instance().set(&DataKey::VoteCast, &Map::<Address, bool>::new(&env));
+        env.storage()
+            .instance()
+            .set(&DataKey::CircleStatus, &CircleStatus::VotingForDissolution);
+        env.storage()
+            .instance()
+            .set(&DataKey::DissolutionVote, &vote);
+        env.storage()
+            .instance()
+            .set(&DataKey::VoteCast, &Map::<Address, bool>::new(&env));
 
         Ok(())
     }
@@ -339,7 +391,8 @@ impl AjoCircle {
     pub fn vote_to_dissolve(env: Env, member: Address) -> Result<(), AjoError> {
         member.require_auth();
 
-        let status: CircleStatus = env.storage()
+        let status: CircleStatus = env
+            .storage()
             .instance()
             .get(&DataKey::CircleStatus)
             .unwrap_or(CircleStatus::Active);
@@ -349,7 +402,8 @@ impl AjoCircle {
         }
 
         // Caller must be a registered member
-        let members: Map<Address, MemberData> = env.storage()
+        let members: Map<Address, MemberData> = env
+            .storage()
             .instance()
             .get(&DataKey::Members)
             .ok_or(AjoError::NotFound)?;
@@ -359,7 +413,8 @@ impl AjoCircle {
         }
 
         // Prevent double-voting
-        let mut vote_cast: Map<Address, bool> = env.storage()
+        let mut vote_cast: Map<Address, bool> = env
+            .storage()
             .instance()
             .get(&DataKey::VoteCast)
             .unwrap_or_else(|| Map::new(&env));
@@ -371,7 +426,8 @@ impl AjoCircle {
         vote_cast.set(member.clone(), true);
         env.storage().instance().set(&DataKey::VoteCast, &vote_cast);
 
-        let mut vote: DissolutionVote = env.storage()
+        let mut vote: DissolutionVote = env
+            .storage()
             .instance()
             .get(&DataKey::DissolutionVote)
             .ok_or(AjoError::NoActiveVote)?;
@@ -388,10 +444,14 @@ impl AjoCircle {
         };
 
         if threshold_met {
-            env.storage().instance().set(&DataKey::CircleStatus, &CircleStatus::Dissolved);
+            env.storage()
+                .instance()
+                .set(&DataKey::CircleStatus, &CircleStatus::Dissolved);
         }
 
-        env.storage().instance().set(&DataKey::DissolutionVote, &vote);
+        env.storage()
+            .instance()
+            .set(&DataKey::DissolutionVote, &vote);
 
         Ok(())
     }
@@ -402,7 +462,8 @@ impl AjoCircle {
     pub fn dissolve_and_refund(env: Env, member: Address) -> Result<i128, AjoError> {
         member.require_auth();
 
-        let status: CircleStatus = env.storage()
+        let status: CircleStatus = env
+            .storage()
             .instance()
             .get(&DataKey::CircleStatus)
             .unwrap_or(CircleStatus::Active);
@@ -411,7 +472,8 @@ impl AjoCircle {
             return Err(AjoError::CircleNotActive);
         }
 
-        let mut members: Map<Address, MemberData> = env.storage()
+        let mut members: Map<Address, MemberData> = env
+            .storage()
             .instance()
             .get(&DataKey::Members)
             .ok_or(AjoError::NotFound)?;
@@ -447,5 +509,37 @@ impl AjoCircle {
             .instance()
             .get(&DataKey::DissolutionVote)
             .ok_or(AjoError::NoActiveVote)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    #[test]
+    fn enforce_member_limit_at_contract_level() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, AjoCircle);
+        let client = AjoCircleClient::new(&env, &contract_id);
+
+        let organizer = Address::generate(&env);
+        let member_one = Address::generate(&env);
+        let member_two = Address::generate(&env);
+        let member_three = Address::generate(&env);
+
+        let init = client.initialize_circle(&organizer, &100_i128, &7_u32, &12_u32, &2_u32);
+        assert_eq!(init, Ok(()));
+
+        let first_join = client.add_member(&organizer, &member_one);
+        assert_eq!(first_join, Ok(()));
+
+        let second_join = client.add_member(&organizer, &member_two);
+        assert_eq!(second_join, Ok(()));
+
+        let third_join = client.add_member(&organizer, &member_three);
+        assert_eq!(third_join, Err(AjoError::CircleAtCapacity));
     }
 }


### PR DESCRIPTION
closes #40 

## Summary
This PR protects the Ajo circle contract from uncontrolled growth and potential resource pressure by enforcing a contract-level member capacity.

## What changed
- Added capacity constants in [contracts/ajo-circle/src/lib.rs](contracts/ajo-circle/src/lib.rs):
  - `MAX_MEMBERS: u32 = 50` (default)
  - `HARD_CAP: u32 = 100` (global maximum)
- Extended `CircleData` to persist `max_members`.
- Updated `initialize_circle(...)` to accept `max_members` and validate inputs:
  - Uses default `MAX_MEMBERS` when `max_members == 0`
  - Rejects values above `HARD_CAP`
- Added `AjoError::CircleAtCapacity` for explicit capacity failures.
- Implemented `join_circle(...)` with contract-level capacity check before insertion.
- Kept backward compatibility by routing existing `add_member(...)` through `join_circle(...)`.
- Added overflow-safe increment for `member_count` using `checked_add(1)`.

## Capacity behavior
- Circle initialization sets a configured member limit.
- Member joins are blocked once limit is reached.
- Failure returns `Err(AjoError::CircleAtCapacity)`.

## Acceptance criteria mapping
- Members cannot join once the limit is reached: ✅
- Limit is enforceable at the contract level: ✅
- Clear error message/signal on failure: ✅ (`CircleAtCapacity`)

## Tests added
Added a focused unit test in [contracts/ajo-circle/src/lib.rs](contracts/ajo-circle/src/lib.rs) that verifies:
1. Initialize with `max_members = 2`.
2. Two joins succeed.
3. Third join fails with `CircleAtCapacity`.

## Notes
- No unrelated contract features were changed.
- `add_member(...)` remains available for compatibility while using the new enforcement logic internally.
