### PR TITLE
fix(api): harden user profile update validation

### DIFF
--- a/lib/validations/user.ts
+++ b/lib/validations/user.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 
 export const UpdateProfileSchema = z.object({
-  firstName: z.string().min(2).max(50).optional(),
-  lastName: z.string().min(2).max(50).optional(),
-  bio: z.string().max(160).optional(),
-  phoneNumber: z.string().max(20).optional(),
-});
+  firstName: z.string().trim().min(2).max(50).optional(),
+  lastName: z.string().trim().min(2).max(50).optional(),
+  bio: z.string().trim().max(160).optional(),
+  phoneNumber: z.string().trim().max(20).optional(),
+}).strict();
 
 export const UpdateWalletSchema = z.object({
   walletAddress: z.string().min(1, 'Wallet address is required'),


### PR DESCRIPTION
closes #22 

## Summary
This PR finalizes the core user profile management API by tightening input validation for profile updates while preserving the existing authenticated `GET` and `PUT` profile flows.

## Scope
- Updated file: [lib/validations/user.ts](lib/validations/user.ts)
- Existing API route covered by this change: [app/api/users/profile/route.ts](app/api/users/profile/route.ts)

## What changed
- Updated `UpdateProfileSchema` to sanitize and strictly validate profile input:
  - Added `.trim()` to `firstName`, `lastName`, `bio`, and `phoneNumber`
  - Added `.strict()` to reject unknown/non-existent fields

## Why this change
The profile route already enforced auth and owner-scoped updates, but unknown payload fields were not explicitly rejected. This change ensures malformed or unexpected profile fields are blocked at validation time, matching the issue testing checklist.

## Acceptance Criteria Mapping
- Profile data correctly persisted in the database: ✅
  - Persisted via existing `PUT` update in [app/api/users/profile/route.ts](app/api/users/profile/route.ts)
- Unauthorized attempts (no JWT) return 401: ✅
  - Enforced in both `GET` and `PUT` in [app/api/users/profile/route.ts](app/api/users/profile/route.ts)
- Users can only edit THEIR OWN profile: ✅
  - Updates are scoped to `payload.userId` in [app/api/users/profile/route.ts](app/api/users/profile/route.ts)

## Security / Data Sanitization
- Sensitive fields are not returned (`password`, privileged flags) because response selection is explicit in [app/api/users/profile/route.ts](app/api/users/profile/route.ts).
- Unknown update fields are now rejected by Zod `.strict()`.

## Testing Checklist Coverage
- Update profile and verify frontend reflects changes: ✅ supported by existing `PUT` path
- Attempt to update fields that don’t exist: ✅ now handled by Zod strict validation

## Risk
- Low risk: validation-only update with no schema migration and no API contract expansion.
