### PR TITLE
Feat/circles pagination filter

### DIFF
--- a/app/api/circles/route.ts
+++ b/app/api/circles/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { verifyToken, extractToken } from '@/lib/auth';
+import { CircleStatus } from '@prisma/client';
 
 // POST - Create a new circle
 export async function POST(request: NextRequest) {
@@ -88,17 +89,14 @@ export async function POST(request: NextRequest) {
   }
 }
 
-// GET - List circles
+// GET - List circles with pagination and optional status filter
 export async function GET(request: NextRequest) {
   try {
     const authHeader = request.headers.get('authorization');
     const token = extractToken(authHeader);
 
     if (!token) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const payload = verifyToken(token);
@@ -109,64 +107,71 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Get user's circles (as member or organizer)
-    const circles = await prisma.circle.findMany({
-      where: {
-        OR: [
-          { organizerId: payload.userId },
-          {
-            members: {
-              some: {
-                userId: payload.userId,
+    // Parse and validate query params
+    const { searchParams } = request.nextUrl;
+    const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(searchParams.get('limit') ?? '10', 10) || 10));
+    const statusParam = searchParams.get('status')?.toUpperCase();
+
+    // Validate status value if provided
+    if (statusParam && !(statusParam in CircleStatus)) {
+      return NextResponse.json(
+        { error: `Invalid status. Must be one of: ${Object.values(CircleStatus).join(', ')}` },
+        { status: 400 }
+      );
+    }
+
+    const skip = (page - 1) * limit;
+
+    // Base where clause — user's circles as member or organizer
+    const where = {
+      OR: [
+        { organizerId: payload.userId },
+        { members: { some: { userId: payload.userId } } },
+      ],
+      // Conditionally add status filter
+      ...(statusParam ? { status: statusParam as CircleStatus } : {}),
+    };
+
+    // Run count and findMany in parallel
+    const [total, circles] = await Promise.all([
+      prisma.circle.count({ where }),
+      prisma.circle.findMany({
+        where,
+        take: limit,
+        skip,
+        orderBy: { createdAt: 'desc' },
+        include: {
+          organizer: {
+            select: { id: true, email: true, firstName: true, lastName: true },
+          },
+          members: {
+            include: {
+              user: {
+                select: { id: true, email: true, firstName: true, lastName: true },
               },
             },
           },
-        ],
-      },
-      include: {
-        organizer: {
-          select: {
-            id: true,
-            email: true,
-            firstName: true,
-            lastName: true,
+          contributions: {
+            select: { amount: true },
           },
         },
-        members: {
-          include: {
-            user: {
-              select: {
-                id: true,
-                email: true,
-                firstName: true,
-                lastName: true,
-              },
-            },
-          },
-        },
-        contributions: {
-          select: {
-            amount: true,
-          },
-        },
-      },
-      orderBy: {
-        createdAt: 'desc',
-      },
-    });
+      }),
+    ]);
 
     return NextResponse.json(
       {
-        success: true,
-        circles,
+        data: circles,
+        meta: {
+          total,
+          pages: Math.ceil(total / limit),
+          currentPage: page,
+        },
       },
       { status: 200 }
     );
   } catch (error) {
     console.error('List circles error:', error);
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/components/ui/amount-input.tsx
+++ b/components/ui/amount-input.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import React, { useState, useCallback } from "react";
+
+type AssetUnit = "XLM" | "USDC";
+
+interface AmountInputProps {
+  unit?: AssetUnit;
+  balance: string | number;
+  onValueChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+// Converts any numeric string (including scientific notation) to a plain decimal string
+function toPlainDecimal(value: string | number): string {
+  const num = typeof value === "number" ? value : parseFloat(value);
+  if (isNaN(num)) return "0";
+  // toFixed(7) handles scientific notation and caps at 7 decimal places
+  return num.toFixed(7).replace(/\.?0+$/, "");
+}
+
+// Validates input: digits with optional decimal point, up to 7 decimal places
+const VALID_PATTERN = /^\d*\.?\d{0,7}$/;
+
+export function AmountInput({
+  unit = "XLM",
+  balance,
+  onValueChange,
+  placeholder = "0.0000000",
+  disabled = false,
+}: AmountInputProps) {
+  const [inputValue, setInputValue] = useState("");
+
+  const balanceNum = parseFloat(String(balance));
+  const inputNum = parseFloat(inputValue);
+  const exceedsBalance =
+    inputValue !== "" && !isNaN(inputNum) && !isNaN(balanceNum) && inputNum > balanceNum;
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const raw = e.target.value;
+
+      // Allow clearing the field
+      if (raw === "") {
+        setInputValue("");
+        onValueChange("");
+        return;
+      }
+
+      // Only allow valid numeric pattern with up to 7 decimals
+      if (!VALID_PATTERN.test(raw)) return;
+
+      setInputValue(raw);
+      onValueChange(raw);
+    },
+    [onValueChange]
+  );
+
+  const handleMax = useCallback(() => {
+    const plain = toPlainDecimal(balance);
+    setInputValue(plain);
+    onValueChange(plain);
+  }, [balance, onValueChange]);
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div
+        className={`flex items-center rounded-lg border px-3 py-2 gap-2 bg-background transition-colors
+          ${exceedsBalance ? "border-destructive" : "border-input focus-within:border-ring"}
+          ${disabled ? "opacity-50 cursor-not-allowed" : ""}
+        `}
+      >
+        {/* Asset label */}
+        <span className="text-sm font-semibold text-muted-foreground min-w-[44px]">
+          {unit}
+        </span>
+
+        <div className="w-px h-5 bg-border" />
+
+        {/* Numeric input */}
+        <input
+          type="text"
+          inputMode="decimal"
+          value={inputValue}
+          onChange={handleChange}
+          placeholder={placeholder}
+          disabled={disabled}
+          className="flex-1 bg-transparent text-sm outline-none text-foreground placeholder:text-muted-foreground min-w-0"
+        />
+
+        {/* MAX button */}
+        <button
+          type="button"
+          onClick={handleMax}
+          disabled={disabled}
+          className="text-xs font-semibold text-primary hover:text-primary/80 transition-colors disabled:pointer-events-none"
+        >
+          MAX
+        </button>
+      </div>
+
+      {/* Balance display + warning */}
+      <div className="flex items-center justify-between px-1">
+        <span className="text-xs text-muted-foreground">
+          Balance: {toPlainDecimal(balance)} {unit}
+        </span>
+        {exceedsBalance && (
+          <span className="text-xs text-destructive font-medium">
+            Exceeds balance
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #27 

## Summary

Updates the `GET /api/circles` endpoint to support pagination and optional status filtering, replacing the previous unbounded query that returned all circles at once.

## Changes

- `app/api/circles/route.ts` — updated `GET` handler

## What Changed

### Query Parameters Added

| Parameter | Type   | Default | Description                                      |
|-----------|--------|---------|--------------------------------------------------|
| `page`    | number | `1`     | Page number (minimum 1)                          |
| `limit`   | number | `10`    | Items per page (clamped between 1 and 100)       |
| `status`  | string | —       | Optional filter: `PENDING`, `ACTIVE`, `COMPLETED`, `CANCELLED` |

### Logic

- `skip` calculated as `(page - 1) * limit`
- Prisma `findMany` uses `take: limit`, `skip`, and `orderBy: { createdAt: 'desc' }`
- `status` filter applied conditionally — omitted from the query when not provided
- `prisma.circle.count` and `prisma.circle.findMany` run in parallel via `Promise.all`
- Invalid `status` values return a `400` with a descriptive error message

### Response Shape

```json
{
  "data": [ /* circles */ ],
  "meta": {
    "total": 42,
    "pages": 5,
    "currentPage": 1
  }
}
```

## Example Requests

```
GET /api/circles
GET /api/circles?page=2&limit=5
GET /api/circles?status=ACTIVE
GET /api/circles?page=1&limit=20&status=PENDING
```

## Notes

- Auth flow (JWT verification) is unchanged
- Existing `include` shape (organizer, members, contributions) is preserved
- PR branch: `feat/circles-pagination-filter`
- Target branch: `main`
