### PR TITLE
feat: add Resend email alerts for payout and contribution reminders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,6 @@ NEXT_PUBLIC_API_URL=http://localhost:3000/api
 # Feature Flags
 NEXT_PUBLIC_ENABLE_GOVERNANCE=true
 NEXT_PUBLIC_ENABLE_PARTIAL_WITHDRAWALS=true
+
+# Email (Resend)
+RESEND_API_KEY=re_your_api_key_here

--- a/app/api/circles/[id]/contribute/route.ts
+++ b/app/api/circles/[id]/contribute/route.ts
@@ -4,6 +4,7 @@ import { verifyToken, extractToken } from '@/lib/auth';
 import { validateBody, applyRateLimit } from '@/lib/api-helpers';
 import { ContributeSchema } from '@/lib/validations/circle';
 import { RATE_LIMITS } from '@/lib/rate-limit';
+import { sendContributionReminder, sendPayoutAlert } from '@/lib/email';
 
 export async function POST(
   request: NextRequest,
@@ -50,6 +51,35 @@ export async function POST(
       where: { circleId_userId: { circleId: id, userId: payload.userId } },
       data: { totalContributed: { increment: data.amount } },
     });
+
+    // Remind all members who haven't contributed this round yet
+    const allMembers = await prisma.circleMember.findMany({
+      where: { circleId: id },
+      include: { user: { select: { email: true, firstName: true } } },
+    });
+    const contributedThisRound = await prisma.contribution.findMany({
+      where: { circleId: id, round: circle.currentRound },
+      select: { userId: true },
+    });
+    const contributedIds = new Set(contributedThisRound.map((c: { userId: string }) => c.userId));
+    for (const m of allMembers) {
+      if (!contributedIds.has(m.userId)) {
+        sendContributionReminder(m.user.email, m.user.firstName, circle.contributionAmount, circle.name);
+      }
+    }
+
+    // If all members have now contributed, alert the payout recipient for this round
+    const totalContributedThisRound = contributedIds.size + 1; // +1 for current contribution
+    if (totalContributedThisRound >= allMembers.length) {
+      const payoutMember = await prisma.circleMember.findFirst({
+        where: { circleId: id, rotationOrder: circle.currentRound },
+        include: { user: { select: { email: true, firstName: true } } },
+      });
+      if (payoutMember) {
+        const payoutAmount = circle.contributionAmount * allMembers.length;
+        sendPayoutAlert(payoutMember.user.email, payoutMember.user.firstName, payoutAmount);
+      }
+    }
 
     return NextResponse.json({ success: true, contribution }, { status: 201 });
   } catch (err) {

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,0 +1,30 @@
+import { Resend } from 'resend';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+const FROM = 'Ajo Platform <alerts@yourdomain.com>';
+
+export async function sendPayoutAlert(email: string, userName: string, amount: number) {
+  try {
+    await resend.emails.send({
+      from: FROM,
+      to: email,
+      subject: "It's your turn — payout ready!",
+      html: `<p>Hi ${userName},</p><p>Your payout of <strong>${amount} XLM</strong> is ready to claim. Log in to your Ajo dashboard to claim it.</p>`,
+    });
+  } catch (err) {
+    console.error('[email] sendPayoutAlert failed:', err);
+  }
+}
+
+export async function sendContributionReminder(email: string, userName: string, amount: number, circleName: string) {
+  try {
+    await resend.emails.send({
+      from: FROM,
+      to: email,
+      subject: `Contribution due for ${circleName}`,
+      html: `<p>Hi ${userName},</p><p>Your contribution of <strong>${amount} XLM</strong> is due for the circle <strong>${circleName}</strong>. Please contribute before the deadline.</p>`,
+    });
+  } catch (err) {
+    console.error('[email] sendContributionReminder failed:', err);
+  }
+}


### PR DESCRIPTION
Closes #28 


Problem

Users had no way of knowing when it was their turn to receive a payout or when a contribution 
was due, requiring them to manually check the dashboard.

Solution
- Created lib/email.ts with two reusable utilities:
  - sendPayoutAlert — notifies the member when it's their turn to claim a payout
  - sendContributionReminder — reminds members who haven't contributed in the current round
- Both functions catch and log errors so a failed email never breaks the API
- Wired both triggers into POST /api/circles/:id/contribute:
  - On each contribution, reminders are sent to all members yet to contribute that round
  - When the round completes (all members contributed), a payout alert is sent to the member 
whose rotation order matches the current round
- RESEND_API_KEY added to .env.example

Configuration
Set RESEND_API_KEY in your environment and update the sender address in lib/email.ts to a 
verified Resend domain before deploying to production.
