### PR TITLE
feat: enforce round contribution deadlines at contract level using le…

### DIFF
--- a/contracts/ajo-circle/src/lib.rs
+++ b/contracts/ajo-circle/src/lib.rs
@@ -16,6 +16,7 @@ pub enum AjoError {
     AlreadyVoted = 9,
     CircleNotActive = 10,
     CircleAlreadyDissolved = 11,
+    DeadlineMissed = 12,
 }
 
 #[contracttype]
@@ -66,6 +67,8 @@ pub enum DataKey {
     DissolutionVote,
     /// Tracks which members have already voted (stored as Map<Address, bool>)
     VoteCast,
+    /// Current round deadline (Unix timestamp u64)
+    RoundDeadline,
 }
 
 #[contract]
@@ -97,6 +100,10 @@ impl AjoCircle {
         };
 
         env.storage().instance().set(&DataKey::Circle, &circle_data);
+
+        // Set first round deadline: now + frequency_days converted to seconds
+        let deadline = env.ledger().timestamp() + (frequency_days as u64) * 86_400;
+        env.storage().instance().set(&DataKey::RoundDeadline, &deadline);
 
         let mut members: Map<Address, MemberData> = Map::new(&env);
         members.set(
@@ -164,6 +171,21 @@ impl AjoCircle {
             return Err(AjoError::InvalidInput);
         }
 
+        // Enforce round deadline
+        let deadline: u64 = env.storage()
+            .instance()
+            .get(&DataKey::RoundDeadline)
+            .ok_or(AjoError::NotFound)?;
+
+        if env.ledger().timestamp() > deadline {
+            return Err(AjoError::DeadlineMissed);
+        }
+
+        let circle: CircleData = env.storage()
+            .instance()
+            .get(&DataKey::Circle)
+            .ok_or(AjoError::NotFound)?;
+
         let mut members: Map<Address, MemberData> = env.storage()
             .instance()
             .get(&DataKey::Members)
@@ -171,12 +193,23 @@ impl AjoCircle {
 
         if let Some(mut member_data) = members.get(member.clone()) {
             member_data.total_contributed += amount;
-            members.set(member, member_data);
+            members.set(member.clone(), member_data);
         } else {
             return Err(AjoError::NotFound);
         }
 
+        // Count contributions this round (total_contributed tracks cumulative; use round * amount as threshold)
+        let round_contributions = members.iter()
+            .filter(|(_, m)| m.total_contributed >= (circle.current_round as i128) * circle.contribution_amount)
+            .count() as u32;
+
         env.storage().instance().set(&DataKey::Members, &members);
+
+        // If all members have contributed this round, advance the deadline
+        if round_contributions >= circle.member_count {
+            let next_deadline = deadline + (circle.frequency_days as u64) * 86_400;
+            env.storage().instance().set(&DataKey::RoundDeadline, &next_deadline);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Closes #25 

 Enforce round contribution deadlines at the contract level

Problem
There was no time constraint on contributions, meaning members could delay 
indefinitely without consequence — undermining the trustless nature of the Ajo 
system.

Solution
- Added AjoError::DeadlineMissed — returned when a contribution is attempted 
after the round deadline
- Added DataKey::RoundDeadline — stores the current round's deadline as a u64 
Unix timestamp on-chain
- initialize_circle now sets the first deadline as 
ledger.timestamp() + frequency_days * 86_400
- contribute enforces the deadline by comparing env.ledger().timestamp() 
against the stored deadline
- When all members complete their contributions for a round, the deadline 
automatically advances by one frequency period (
deadline + frequency_days * 86_400), keeping deadlines anchored to the original
start rather than drifting

Behaviour
- Contribution at T+1 → accepted ✅
- Contribution at T + frequency + 1 → rejected with DeadlineMissed ✅
- Deadline advances cleanly round-over-round without organizer intervention ✅
