### PR TITLE
fix: optimize loop counter types in slice functions (#159)

### DIFF
--- a/contracts/ethereum/contracts/AjoCircle.sol
+++ b/contracts/ethereum/contracts/AjoCircle.sol
@@ -113,7 +113,7 @@ contract AjoCircle is Initializable, OwnableUpgradeable, ReentrancyGuardUpgradea
         }
 
         address[] memory slice = new address[](count);
-        for (uint32 i = 0; i < count; i++) {
+        for (uint256 i = 0; i < count; i++) {
             slice[i] = memberAddresses[_offset + i];
         }
         return slice;
@@ -127,7 +127,7 @@ contract AjoCircle is Initializable, OwnableUpgradeable, ReentrancyGuardUpgradea
         }
 
         address[] memory slice = new address[](count);
-        for (uint32 i = 0; i < count; i++) {
+        for (uint256 i = 0; i < count; i++) {
             slice[i] = rotationOrder[_offset + i];
         }
         return slice;

--- a/contracts/ethereum/contracts/AjoFactory.sol
+++ b/contracts/ethereum/contracts/AjoFactory.sol
@@ -114,7 +114,7 @@ contract AjoFactory is Ownable {
         }
 
         address[] memory slice = new address[](count);
-        for (uint32 i = 0; i < count; i++) {
+        for (uint256 i = 0; i < count; i++) {
             slice[i] = ajoRegistry[_offset + i];
         }
         return slice;


### PR DESCRIPTION
Closes #159

This PR optimizes loop iterations in the Ethereum slice view functions by aligning the loop counter type with `count` (`uint256`).

Updated functions:
- `AjoCircle.getMemberAddressesSlice`
- `AjoCircle.getRotationOrderSlice`
- `AjoFactory.getRegistrySlice`

What changed:
- replaced `uint32` loop counters with `uint256`

Why:
- avoids unnecessary type conversions inside the loop
- reduces arithmetic overhead in repeated iterations
- preserves existing behavior

Note:
I attempted a local Hardhat compile check, but the repository currently appears to have a tooling/config mismatch around ESM vs CommonJS in the Hardhat setup. No tooling/config files were changed in this PR.

No functional logic was changed.