### PR TITLE
feat: add Sepolia deployment script for Ajo and AjoFactory (#164)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
     "test": "npm run test:contracts",
-    "test:contracts": "cd contracts/ajo-circle && cargo test --lib"
+    "test:contracts": "cd contracts/ajo-circle && cargo test --lib",
+    "deploy:sepolia": "hardhat run scripts/deploy.js --network sepolia"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,17 @@
+const hre = require("hardhat");
+
+async function main() {
+  const implementation = await hre.ethers.deployContract("Ajo");
+  await implementation.waitForDeployment();
+  console.log(`Ajo implementation deployed to ${implementation.target}`);
+
+  const AjoFactory = await hre.ethers.getContractFactory("AjoFactory");
+  const factory = await AjoFactory.deploy(implementation.target);
+  await factory.waitForDeployment();
+  console.log(`AjoFactory deployed to ${factory.target}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Adds a Hardhat deploy script that deploys the Ajo implementation contract followed by AjoFactory on Sepolia testnet, and wires it to an npm script for easy execution.

Closes #164
