### PR TITLE
fix(api): migrate /api/profile auth from wallet header to JWT Bearer

### DIFF
--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -1,52 +1,83 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
+import { verifyToken, extractToken } from '@/lib/auth';
+import { validateBody, applyRateLimit } from '@/lib/api-helpers';
+import { UpdateProfileSchema } from '@/lib/validations/user';
+import { RATE_LIMITS } from '@/lib/rate-limit';
 
-export async function PUT(req: Request) {
+const USER_SELECT = {
+  id: true,
+  email: true,
+  username: true,
+  firstName: true,
+  lastName: true,
+  notificationEmail: true,
+  bio: true,
+  phoneNumber: true,
+  profilePicture: true,
+  walletAddress: true,
+  createdAt: true,
+};
+
+export async function GET(request: NextRequest) {
+  const token = extractToken(request.headers.get('authorization'));
+  if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const payload = verifyToken(token);
+  if (!payload) return NextResponse.json({ error: 'Invalid or expired token' }, { status: 401 });
+
+  const rateLimited = applyRateLimit(request, RATE_LIMITS.api, 'profile-get', payload.userId);
+  if (rateLimited) return rateLimited;
+
   try {
-    const userAddress = req.headers.get('x-wallet-address'); 
-    if (!userAddress) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-    const body = await req.json();
-    const { username, email } = body;
-
-    if (!username || !email) {
-      return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
-    }
-
-    const user = await prisma.user.upsert({
-      where: { address: userAddress },
-      update: { username, email },
-      create: { address: userAddress, username, email },
-    });
-
-    return NextResponse.json(user, { status: 200 });
+    const user = await prisma.user.findUnique({ where: { id: payload.userId }, select: USER_SELECT });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    return NextResponse.json({ success: true, user });
   } catch (error) {
-    console.error('Database mutation failed:', error);
-    return NextResponse.json({ error: 'Database mutation failed' }, { status: 500 });
+    console.error('Get profile error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }
 
-export async function GET(req: Request) {
-  try {
-    const userAddress = req.headers.get('x-wallet-address');
-    if (!userAddress) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+export async function PUT(request: NextRequest) {
+  const token = extractToken(request.headers.get('authorization'));
+  if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-    const user = await prisma.user.findUnique({
-      where: { address: userAddress },
-      select: {
-        id: true,
-        email: true,
-        username: true,
-        address: true,
-        firstName: true,
-        lastName: true,
-      }
+  const payload = verifyToken(token);
+  if (!payload) return NextResponse.json({ error: 'Invalid or expired token' }, { status: 401 });
+
+  const rateLimited = applyRateLimit(request, RATE_LIMITS.api, 'profile-update', payload.userId);
+  if (rateLimited) return rateLimited;
+
+  const { data, error } = await validateBody(request, UpdateProfileSchema);
+  if (error) return error;
+
+  try {
+    const user = await prisma.user.update({
+      where: { id: payload.userId },
+      data: {
+        ...(data.email !== undefined && { email: data.email.trim().toLowerCase() }),
+        ...(data.username !== undefined && {
+          username: data.username.trim() === '' ? null : data.username.trim(),
+        }),
+        ...(data.firstName !== undefined && { firstName: data.firstName.trim() }),
+        ...(data.lastName !== undefined && { lastName: data.lastName.trim() }),
+        ...(data.notificationEmail !== undefined && {
+          notificationEmail: data.notificationEmail.trim() === '' ? null : data.notificationEmail.trim(),
+        }),
+        ...(data.bio !== undefined && { bio: data.bio }),
+        ...(data.phoneNumber !== undefined && { phoneNumber: data.phoneNumber }),
+      },
+      select: USER_SELECT,
     });
 
-    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
-
-    return NextResponse.json(user, { status: 200 });
-  } catch (error) {
+    return NextResponse.json({ success: true, user });
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+      return NextResponse.json({ error: 'That username or email is already taken' }, { status: 409 });
+    }
+    console.error('Update profile error:', err);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }


### PR DESCRIPTION
  The PUT /api/profile and GET /api/profile endpoints were authenticating via a deprecated x-wallet-address header,
  while app/settings/page.tsx (the ProfileSettings page) was correctly sending Authorization: Bearer <token>. This
  mismatch caused silent 401 errors on every request, making the profile settings form non-functional.

  Changes:
  - Replaced x-wallet-address header auth with extractToken + verifyToken (JWT)
  - User lookup now uses payload.userId instead of wallet address
  - Body validation via UpdateProfileSchema (Zod)
  - Responses now return { success: true, user } matching what the client expects
  - Added rate limiting consistent with the rest of the API
  - Added P2002 conflict handling (duplicate username/email → 409)

  Closes #133 