### PR TITLE
feat(cron): identify cycle winner, send payout email and PAYOUT_TURN …

### DIFF
--- a/server/services/ajo-cycle-cron.ts
+++ b/server/services/ajo-cycle-cron.ts
@@ -1,5 +1,6 @@
 import cron from 'node-cron';
 import { prisma } from '@/lib/prisma';
+import { sendPayoutAlert } from '@/lib/email';
 import logger from '../config/logger';
 
 const CRON_SCHEDULE = '0 * * * *';
@@ -18,6 +19,9 @@ async function processEndedAjoCycles(): Promise<void> {
       id: true,
       name: true,
       expectedEndDate: true,
+      currentRound: true,
+      maxRounds: true,
+      contributionAmount: true,
       organizer: {
         select: {
           id: true,
@@ -26,11 +30,17 @@ async function processEndedAjoCycles(): Promise<void> {
         },
       },
       members: {
+        where: { status: 'ACTIVE' },
         select: {
           userId: true,
+          rotationOrder: true,
+          hasReceivedPayout: true,
           user: {
             select: {
+              email: true,
               notificationEmail: true,
+              firstName: true,
+              username: true,
             },
           },
         },
@@ -46,33 +56,83 @@ async function processEndedAjoCycles(): Promise<void> {
 
   for (const cycle of endedCycles) {
     try {
+      const winner = cycle.members.find(
+        (m) => m.rotationOrder === cycle.currentRound && !m.hasReceivedPayout,
+      );
+
+      const isLastRound = cycle.currentRound >= cycle.maxRounds;
+      const newStatus = isLastRound ? 'COMPLETED' : 'ACTION_REQUIRED';
+
       await prisma.circle.update({
         where: { id: cycle.id },
-        data: { status: 'ACTION_REQUIRED' },
+        data: {
+          status: newStatus,
+          currentRound: { increment: 1 },
+        },
       });
+
+      if (winner) {
+        await prisma.circleMember.update({
+          where: { circleId_userId: { circleId: cycle.id, userId: winner.userId } },
+          data: { hasReceivedPayout: true },
+        });
+      }
+
+      const winnerNotification = winner
+        ? {
+            userId: winner.userId,
+            type: 'PAYOUT_TURN' as const,
+            title: "It's your turn — payout ready!",
+            message: `Your payout of ${cycle.contributionAmount} XLM is ready to claim from the Ajo group "${cycle.name}". Log in to your dashboard to claim it.`,
+            circleId: cycle.id,
+            link: `/ajo/${cycle.id}`,
+          }
+        : null;
+
+      const otherMemberNotifications = cycle.members
+        .filter((m) => m.userId !== winner?.userId)
+        .map((member) => ({
+          userId: member.userId,
+          type: 'GENERAL' as const,
+          title: isLastRound ? 'Ajo Cycle Completed' : 'Ajo Cycle Ended',
+          message: isLastRound
+            ? `The Ajo group "${cycle.name}" has completed all rounds successfully.`
+            : `The Ajo group "${cycle.name}" has reached its expected end date. The organizer will review next steps.`,
+          circleId: cycle.id,
+          link: `/ajo/${cycle.id}`,
+        }));
+
+      const organizerNotification = {
+        userId: cycle.organizer.id,
+        type: 'GENERAL' as const,
+        title: isLastRound ? 'Ajo Cycle Completed - Action Required' : 'Ajo Cycle Ended - Action Required',
+        message: isLastRound
+          ? `Your Ajo group "${cycle.name}" has completed all rounds. Please verify the final payout on-chain.`
+          : `Your Ajo group "${cycle.name}" has reached its expected end date. Please verify the payout on-chain and confirm.`,
+        circleId: cycle.id,
+        link: `/ajo/${cycle.id}`,
+      };
 
       await prisma.notification.createMany({
         data: [
-          {
-            userId: cycle.organizer.id,
-            type: 'GENERAL',
-            title: 'Ajo Cycle Ended - Action Required',
-            message: `Your Ajo group "${cycle.name}" has reached its expected end date. Please review and take necessary action.`,
-            circleId: cycle.id,
-            link: `/ajo/${cycle.id}`,
-          },
-          ...cycle.members.map((member) => ({
-            userId: member.userId,
-            type: 'GENERAL' as const,
-            title: 'Ajo Cycle Ended',
-            message: `The Ajo group "${cycle.name}" has reached its expected end date. The organizer will review next steps.`,
-            circleId: cycle.id,
-            link: `/ajo/${cycle.id}`,
-          })),
+          ...(winnerNotification ? [winnerNotification] : []),
+          ...otherMemberNotifications,
+          organizerNotification,
         ],
       });
 
-      logger.info(`[cron:ajo-cycle] Updated cycle ${cycle.id} (${cycle.name}) to ACTION_REQUIRED`);
+      if (winner) {
+        const winnerEmail = winner.user.notificationEmail ?? winner.user.email;
+        const winnerName =
+          winner.user.firstName ?? winner.user.username ?? winnerEmail;
+
+        await sendPayoutAlert(winnerEmail, winnerName, cycle.contributionAmount);
+      }
+
+      logger.info(
+        `[cron:ajo-cycle] Processed cycle ${cycle.id} (${cycle.name}) → ${newStatus}` +
+          (winner ? ` | winner: ${winner.userId} (round ${cycle.currentRound})` : ' | no winner found for round'),
+      );
     } catch (error) {
       logger.error(`[cron:ajo-cycle] Failed to process cycle ${cycle.id}`, { error });
     }


### PR DESCRIPTION
  The cron job was notifying all members generically with GENERAL type on every cycle end, but had no concept of who the
   current round's winner was, no email dispatch, and no final completion state.

  Changes to server/services/ajo-cycle-cron.ts:
  - Winner identified via rotationOrder === currentRound && !hasReceivedPayout
  - Winner receives a PAYOUT_TURN notification (enum value that was defined but never used)
  - sendPayoutAlert() email dispatched to winner's notificationEmail (fallback to email)
  - CircleMember.hasReceivedPayout set to true for the winner
  - Circle.currentRound incremented after each processed cycle
  - Status transitions to COMPLETED when currentRound >= maxRounds, otherwise ACTION_REQUIRED pending on-chain
  confirmation
  - Organizer and remaining members still receive GENERAL notifications with round-aware messaging

  Closes #145 