### PR TITLE
feat: standardize currency/amount display with Intl formatter (closes #320)

### DIFF
--- a/app/circles/[id]/page.tsx
+++ b/app/circles/[id]/page.tsx
@@ -12,6 +12,7 @@ import { toast } from 'sonner';
 import { authenticatedFetch } from '@/lib/auth-client';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { AdminPanel } from './components/admin-panel';
+import { formatAmount } from '@/lib/utils';
 
 interface Member {
   id: string;
@@ -102,10 +103,6 @@ function getStatusVariant(status: string): 'default' | 'secondary' | 'destructiv
     default:
       return 'secondary';
   }
-}
-
-function formatXLM(n: number): string {
-  return Number.isFinite(n) ? n.toLocaleString(undefined, { maximumFractionDigits: 7 }) : '0';
 }
 
 export default function CircleDetailPage() {
@@ -233,7 +230,7 @@ export default function CircleDetailPage() {
             </div>
             <div className="text-right">
               <p className="text-sm text-muted-foreground">Current Pot</p>
-              <p className="text-3xl font-bold text-primary">{formatXLM(totalPot)} XLM</p>
+              <p className="text-3xl font-bold text-primary">{formatAmount(totalPot)} XLM</p>
             </div>
           </div>
         </div>
@@ -263,7 +260,7 @@ export default function CircleDetailPage() {
               <TrendingUp className="h-5 w-5 text-muted-foreground" />
               <div>
                 <p className="text-sm text-muted-foreground">Per Round</p>
-                <p className="text-lg font-bold">{formatXLM(circle.contributionAmount)} XLM</p>
+                <p className="text-lg font-bold">{formatAmount(circle.contributionAmount)} XLM</p>
               </div>
             </div>
             <div className="flex items-center gap-3">
@@ -271,7 +268,7 @@ export default function CircleDetailPage() {
               <div>
                 <p className="text-sm text-muted-foreground">Payout</p>
                 <p className="text-lg font-bold">
-                  {formatXLM(circle.contributionAmount * circle.members.length)} XLM
+                  {formatAmount(circle.contributionAmount * circle.members.length)} XLM
                 </p>
               </div>
             </div>
@@ -384,7 +381,7 @@ export default function CircleDetailPage() {
                       <div className="text-right">
                         <p className="text-sm">
                           <span className="text-muted-foreground">Contributed: </span>
-                          <span className="font-semibold">{member.totalContributed} XLM</span>
+                          <span className="font-semibold">{formatAmount(member.totalContributed)} XLM</span>
                         </p>
                         {member.hasReceivedPayout && (
                           <span className="text-xs bg-primary/10 text-primary px-2 py-1 rounded">
@@ -428,7 +425,7 @@ export default function CircleDetailPage() {
                           <p className="text-sm text-muted-foreground">Round {contribution.round}</p>
                         </div>
                         <div className="text-right">
-                          <p className="font-semibold">{contribution.amount} XLM</p>
+                          <p className="font-semibold">{formatAmount(contribution.amount)} XLM</p>
                           <p className="text-sm text-muted-foreground">{contribution.status}</p>
                         </div>
                       </div>

--- a/app/circles/create/page.tsx
+++ b/app/circles/create/page.tsx
@@ -11,6 +11,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { ArrowLeft } from 'lucide-react';
 import { toast } from 'sonner';
 import { authenticatedFetch } from '@/lib/auth-client';
+import { formatAmount } from '@/lib/utils';
 
 export default function CreateCirclePage() {
   const router = useRouter();
@@ -248,7 +249,7 @@ export default function CreateCirclePage() {
                     <span className="text-muted-foreground">Payout Per Round:</span>{' '}
                     <span className="font-semibold">
                       {formData.contributionAmount && formData.maxRounds
-                        ? `${(parseFloat(formData.contributionAmount) * parseInt(formData.maxRounds)).toFixed(2)} XLM`
+                        ? `${formatAmount(parseFloat(formData.contributionAmount) * parseInt(formData.maxRounds))} XLM`
                         : '-'}
                     </span>
                   </p>

--- a/app/circles/join/page.tsx
+++ b/app/circles/join/page.tsx
@@ -10,6 +10,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
 import { authenticatedFetch } from '@/lib/auth-client';
+import { formatAmount } from '@/lib/utils';
 
 interface CirclePreview {
   id: string;
@@ -198,7 +199,7 @@ function JoinCircleContent() {
               <div className="grid grid-cols-3 gap-4 text-center">
                 <div className="p-3 rounded-lg bg-muted">
                   <TrendingUp className="h-4 w-4 mx-auto mb-1 text-muted-foreground" />
-                  <p className="text-lg font-bold">{preview.contributionAmount} XLM</p>
+                  <p className="text-lg font-bold">{formatAmount(preview.contributionAmount)} XLM</p>
                   <p className="text-xs text-muted-foreground">Per round</p>
                 </div>
                 <div className="p-3 rounded-lg bg-muted">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -14,6 +14,7 @@ import { Dashboard } from '@/components/dashboard';
 import { DashboardStats } from '@/components/dashboard/dashboard-stats';
 import { DashboardStatsSkeleton } from '@/components/dashboard/stats-skeleton';
 import { CircleList } from '@/components/dashboard/circle-list';
+import { formatAmount } from '@/lib/utils';
 import DashboardCard from '@/components/DashboardCard';
 import DashboardSkeleton from '@/components/dashboard-skeleton';
 import {
@@ -114,7 +115,7 @@ export default function DashboardPage() {
         return {
           id: circle.id,
           name: circle.name,
-          balance: `${totalBalance.toLocaleString()} XLM`,
+          balance: `${formatAmount(totalBalance)} XLM`,
           nextCycle,
         };
       });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import { Input } from '@/components/ui/input';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { CircleList } from '@/components/dashboard/circle-list';
 import { authenticatedFetch } from '@/lib/auth-client';
+import { formatAmount } from '@/lib/utils';
 import {
   Pagination,
   PaginationContent,
@@ -209,7 +210,7 @@ export default function Home() {
             </CardHeader>
             <CardContent>
               <div className="text-2xl font-bold">
-                {circles.reduce((acc, c) => acc + (c.contributionAmount || 0), 0).toFixed(2)} XLM
+                {formatAmount(circles.reduce((acc, c) => acc + (c.contributionAmount || 0), 0))} XLM
               </div>
               <p className="text-xs text-muted-foreground">Combined contributions</p>
             </CardContent>

--- a/app/transactions/page.tsx
+++ b/app/transactions/page.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
 import { TransactionTable, type Transaction } from '@/components/transaction-table';
 import { authenticatedFetch } from '@/lib/auth-client';
+import { formatAmount } from '@/lib/utils';
 
 // The interface and statusVariant are no longer needed here 
 // because they are imported from '@/components/transaction-table'
@@ -119,7 +120,7 @@ export default function TransactionsPage() {
                       </Badge>
                     </TableCell>
                     <TableCell className="text-right font-mono text-sm">
-                      {tx.amount.toFixed(2)} XLM
+                      {formatAmount(tx.amount)} XLM
                     </TableCell>
                   </TableRow>
                 ))}

--- a/components/dashboard-card.tsx
+++ b/components/dashboard-card.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Wallet, Calendar, TrendingUp } from 'lucide-react';
+import { formatAmount } from '@/lib/utils';
 
 interface DashboardCardProps {
   title: string;
@@ -38,7 +39,7 @@ export const DashboardCard: React.FC<DashboardCardProps> = ({
               Pooled Balance
             </p>
             <p className="text-lg font-mono font-bold text-foreground">
-              {typeof pooledBalance === 'number' ? `${pooledBalance.toLocaleString()} XLM` : pooledBalance}
+              {typeof pooledBalance === 'number' ? `${formatAmount(pooledBalance)} XLM` : pooledBalance}
             </p>
           </div>
         </div>

--- a/components/dashboard/circle-list.tsx
+++ b/components/dashboard/circle-list.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { CircleDot, ArrowRight, Wallet, Users, LayoutGrid } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { CircleListSkeleton } from './circle-list-skeleton';
+import { formatAmount } from '@/lib/utils';
 
 interface Circle {
   id: string;
@@ -74,7 +75,7 @@ export function CircleList({ circles, loading }: CircleListProps) {
                   <p className="text-[10px] uppercase font-bold text-muted-foreground flex items-center gap-1">
                     <Wallet className="h-3 w-3" /> Entry
                   </p>
-                  <p className="text-sm font-semibold">{circle.contributionAmount} XLM</p>
+                  <p className="text-sm font-semibold">{formatAmount(circle.contributionAmount)} XLM</p>
                 </div>
               </div>
               <div className="border-t pt-4 flex items-center justify-between text-primary font-bold text-xs">

--- a/components/dashboard/dashboard-stats.tsx
+++ b/components/dashboard/dashboard-stats.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { CircleDot, Users, TrendingUp, Wallet } from 'lucide-react';
 import { authenticatedFetch } from '@/lib/auth-client';
+import { formatAmount } from '@/lib/utils';
 
 interface Stats {
   activeCircles: number;
@@ -89,7 +90,7 @@ export function DashboardStats() {
           <TrendingUp className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{stats.totalContributed.toFixed(2)} XLM</div>
+          <div className="text-2xl font-bold">{formatAmount(stats.totalContributed)} XLM</div>
           <p className="text-xs text-muted-foreground">{stats.contributionCount} contributions</p>
         </CardContent>
       </Card>
@@ -100,7 +101,7 @@ export function DashboardStats() {
           <Wallet className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{stats.totalWithdrawn.toFixed(2)} XLM</div>
+          <div className="text-2xl font-bold">{formatAmount(stats.totalWithdrawn)} XLM</div>
           <p className="text-xs text-muted-foreground">Emergency withdrawals</p>
         </CardContent>
       </Card>

--- a/components/dashboard/upcoming-cycles.tsx
+++ b/components/dashboard/upcoming-cycles.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Calendar, Clock, ArrowRight } from 'lucide-react';
 import { authenticatedFetch } from '@/lib/auth-client';
 import { formatDistanceToNow, addDays } from 'date-fns';
+import { formatAmount } from '@/lib/utils';
 
 interface Circle {
   id: string;
@@ -110,7 +111,7 @@ export function UpcomingCycles() {
                 <div className="min-w-0">
                   <p className="text-sm font-medium truncate">{circle.name}</p>
                   <p className="text-xs text-muted-foreground">
-                    Round {circle.currentRound}/{circle.maxRounds} · {payout.toFixed(2)} XLM payout
+                    Round {circle.currentRound}/{circle.maxRounds} · {formatAmount(payout)} XLM payout
                   </p>
                 </div>
               </div>

--- a/components/transaction-table.tsx
+++ b/components/transaction-table.tsx
@@ -6,7 +6,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ArrowUpDown, ChevronDown, ChevronUp } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { cn, formatAmount } from '@/lib/utils';
 
 export interface Transaction {
   id: string;
@@ -81,7 +81,7 @@ export function TransactionTable({ transactions, onSort, sortBy, order }: Transa
                   </Badge>
                 </TableCell>
                 <TableCell className="text-right font-mono text-sm">
-                  {tx.amount.toFixed(2)} XLM
+                  {formatAmount(tx.amount)} XLM
                 </TableCell>
               </TableRow>
             ))}
@@ -107,7 +107,7 @@ export function TransactionTable({ transactions, onSort, sortBy, order }: Transa
             <span className="text-sm text-muted-foreground md:text-black">
               {new Date(tx.createdAt).toLocaleDateString()}
             </span>
-            <span className="font-semibold">{tx.amount.toFixed(2)} XLM</span>
+            <span className="font-semibold">{formatAmount(tx.amount)} XLM</span>
             <span className="text-blue-600">
               <Link href={`/circles/${tx.circle.id}`} className="hover:underline">
                 {tx.circle.name}
@@ -143,7 +143,7 @@ export function TransactionCard({ transaction }: { transaction: Transaction }) {
             })}
           </p>
           <p className="text-xl font-bold tracking-tight">
-            {transaction.amount.toFixed(2)} <span className="text-sm font-normal text-muted-foreground">XLM</span>
+            {formatAmount(transaction.amount)} <span className="text-sm font-normal text-muted-foreground">XLM</span>
           </p>
         </div>
         <Badge variant={statusVariant[transaction.status] ?? 'secondary'} className="h-fit py-0.5 px-2">

--- a/components/ui/amount-input.tsx
+++ b/components/ui/amount-input.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useCallback } from "react";
+import { ASSET_DECIMALS } from "@/lib/utils";
 
 type AssetUnit = "XLM" | "USDC";
 
@@ -13,24 +14,28 @@ interface AmountInputProps {
 }
 
 // Converts any numeric string (including scientific notation) to a plain decimal string
-function toPlainDecimal(value: string | number): string {
+function toPlainDecimal(value: string | number, decimals: number): string {
   const num = typeof value === "number" ? value : parseFloat(value);
   if (isNaN(num)) return "0";
-  // toFixed(7) handles scientific notation and caps at 7 decimal places
-  return num.toFixed(7).replace(/\.?0+$/, "");
+  return num.toFixed(decimals).replace(/\.?0+$/, "");
 }
 
-// Validates input: digits with optional decimal point, up to 7 decimal places
-const VALID_PATTERN = /^\d*\.?\d{0,7}$/;
+// Build a regex that allows up to `decimals` decimal places
+function buildPattern(decimals: number): RegExp {
+  return new RegExp(`^\\d*\\.?\\d{0,${decimals}}$`);
+}
 
 export function AmountInput({
   unit = "XLM",
   balance,
   onValueChange,
-  placeholder = "0.0000000",
+  placeholder,
   disabled = false,
 }: AmountInputProps) {
   const [inputValue, setInputValue] = useState("");
+  const decimals = ASSET_DECIMALS[unit] ?? 7;
+  const validPattern = buildPattern(decimals);
+  const resolvedPlaceholder = placeholder ?? `0.${"0".repeat(decimals)}`;
 
   const balanceNum = parseFloat(String(balance));
   const inputNum = parseFloat(inputValue);
@@ -41,27 +46,25 @@ export function AmountInput({
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const raw = e.target.value;
 
-      // Allow clearing the field
       if (raw === "") {
         setInputValue("");
         onValueChange("");
         return;
       }
 
-      // Only allow valid numeric pattern with up to 7 decimals
-      if (!VALID_PATTERN.test(raw)) return;
+      if (!validPattern.test(raw)) return;
 
       setInputValue(raw);
       onValueChange(raw);
     },
-    [onValueChange]
+    [onValueChange, validPattern]
   );
 
   const handleMax = useCallback(() => {
-    const plain = toPlainDecimal(balance);
+    const plain = toPlainDecimal(balance, decimals);
     setInputValue(plain);
     onValueChange(plain);
-  }, [balance, onValueChange]);
+  }, [balance, decimals, onValueChange]);
 
   return (
     <div className="flex flex-col gap-1">
@@ -84,7 +87,7 @@ export function AmountInput({
           inputMode="decimal"
           value={inputValue}
           onChange={handleChange}
-          placeholder={placeholder}
+          placeholder={resolvedPlaceholder}
           disabled={disabled}
           className="flex-1 bg-transparent text-sm outline-none text-foreground placeholder:text-muted-foreground min-w-0"
         />
@@ -103,7 +106,7 @@ export function AmountInput({
       {/* Balance display + warning */}
       <div className="flex items-center justify-between px-1">
         <span className="text-xs text-muted-foreground">
-          Balance: {toPlainDecimal(balance)} {unit}
+          Balance: {toPlainDecimal(balance, decimals)} {unit}
         </span>
         {exceedsBalance && (
           <span className="text-xs text-destructive font-medium">

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,11 +5,39 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export function formatXLM(amount: number): string {
-  return new Intl.NumberFormat('en-US', {
+/**
+ * Decimal precision per asset (matches on-chain / testnet config).
+ * XLM  – 7 decimals (1 XLM = 10,000,000 stroops)
+ * USDC – 2 decimals (standard fiat-pegged stablecoin on Stellar testnet)
+ */
+export const ASSET_DECIMALS: Record<string, number> = {
+  XLM: 7,
+  USDC: 2,
+}
+
+/**
+ * Format a numeric amount for display using Intl.NumberFormat.
+ * Respects the user's locale for grouping separators.
+ *
+ * @param amount  - The numeric value to format
+ * @param asset   - Asset ticker (e.g. "XLM", "USDC"). Defaults to "XLM"
+ * @param locale  - BCP 47 locale string. Defaults to the runtime locale
+ */
+export function formatAmount(
+  amount: number,
+  asset: string = 'XLM',
+  locale?: string,
+): string {
+  const decimals = ASSET_DECIMALS[asset] ?? 2
+  return new Intl.NumberFormat(locale, {
     minimumFractionDigits: 2,
-    maximumFractionDigits: 7,
+    maximumFractionDigits: decimals,
   }).format(amount)
+}
+
+/** @deprecated Use formatAmount(amount, 'XLM') instead */
+export function formatXLM(amount: number): string {
+  return formatAmount(amount, 'XLM')
 }
 
 export function formatDate(date: string | Date): string {


### PR DESCRIPTION
## Summary

Resolves #320 — all user-visible amounts now go through a single shared `formatAmount()` helper using `Intl.NumberFormat`, ensuring consistent locale-aware display across the app.

## Changes

### `lib/utils.ts`
- Added `ASSET_DECIMALS` constant (XLM = 7, USDC = 2) — documents assumed decimals per testnet asset
- Added `formatAmount(amount, asset?, locale?)` — locale-aware, respects per-asset decimal precision
- `formatXLM` kept as a deprecated wrapper for backward compatibility

### `components/ui/amount-input.tsx`
- Validation regex now derived from `ASSET_DECIMALS[unit]` — mismatch between input max-decimals and chain is caught at entry
- Balance display and MAX button use per-asset decimal precision

### All display sites (13 files)
Replaced every raw `.toFixed()` / `.toLocaleString()` / inline `formatXLM` call with `formatAmount()`:
- `app/circles/[id]/page.tsx` — removed duplicate local `formatXLM`
- `app/circles/create/page.tsx`
- `app/circles/join/page.tsx`
- `app/page.tsx`
- `app/dashboard/page.tsx`
- `app/transactions/page.tsx`
- `components/dashboard/dashboard-stats.tsx`
- `components/dashboard/upcoming-cycles.tsx`
- `components/dashboard/circle-list.tsx`
- `components/transaction-table.tsx`
- `components/dashboard-card.tsx`

## Acceptance criteria
- ✅ All user-visible amounts use the shared formatter
- ✅ Locale grouping separators work correctly (Intl.NumberFormat respects runtime locale)
- ✅ Input max-decimals aligned with chain via `ASSET_DECIMALS`