### PR TITLE
feat: require email verification before login and circle access

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -32,6 +32,15 @@ export async function POST(request: NextRequest) {
 
     const user = await prisma.user.findUnique({
       where: { email: email.toLowerCase() },
+      select: {
+        id: true,
+        email: true,
+        password: true,
+        firstName: true,
+        lastName: true,
+        walletAddress: true,
+        verified: true,
+      },
     });
 
     if (!user) {
@@ -41,6 +50,14 @@ export async function POST(request: NextRequest) {
     const isValidPassword = await verifyPassword(password, user.password);
     if (!isValidPassword) {
       return errorResponse(request, { code: 'invalid_credentials', message: 'Invalid email or password' }, 401);
+    }
+
+    if (!user.verified) {
+      return errorResponse(
+        request,
+        { code: 'email_not_verified', message: 'Please verify your email address before logging in.' },
+        403,
+      );
     }
 
     const token = generateToken({

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -4,12 +4,7 @@ import { z } from 'zod';
 import { prisma } from '@/lib/prisma';
 import {
   hashPassword,
-  generateToken,
   validatePasswordStrength,
-  generateRefreshToken,
-  REFRESH_TOKEN_COOKIE_NAME,
-  getRefreshTokenExpiryDate,
-  isSecureCookieEnvironment,
 } from '@/lib/auth';
 import { validateBody, applyRateLimit } from '@/lib/api-helpers';
 import { RegisterSchema } from '@/lib/validations/auth';
@@ -86,21 +81,10 @@ export async function POST(request: NextRequest) {
       logger.error('Failed to send verification email during registration', { err, userId: user.newUser.id });
     });
 
-    const token = generateToken({ userId: user.newUser.id, email: user.newUser.email });
-    const refreshToken = await generateRefreshToken(user.newUser.id);
-
-    const response = NextResponse.json({ success: true, user: user.newUser, token }, { status: 201 });
-    response.cookies.set({
-      name: REFRESH_TOKEN_COOKIE_NAME,
-      value: refreshToken,
-      httpOnly: true,
-      secure: isSecureCookieEnvironment(),
-      sameSite: 'lax',
-      path: '/',
-      expires: getRefreshTokenExpiryDate(),
-    });
-
-    return response;
+    return NextResponse.json(
+      { success: true, message: 'Registration successful. Please check your email to verify your account.' },
+      { status: 201 },
+    );
   } catch (err) {
     logger.error('Registration error', { err });
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/app/api/circles/[id]/join/route.ts
+++ b/app/api/circles/[id]/join/route.ts
@@ -68,6 +68,17 @@ export async function POST(
   try {
     const { id } = await params;
 
+    const user = await prisma.user.findUnique({
+      where: { id: payload.userId },
+      select: { verified: true },
+    });
+    if (!user?.verified) {
+      return NextResponse.json(
+        { error: 'Email verification required to join a circle.' },
+        { status: 403 },
+      );
+    }
+
     const circle = await prisma.circle.findUnique({
       where: { id },
       include: { members: true },


### PR DESCRIPTION
- Register: no longer issues JWT on signup; returns 201 with a 'check your email' message. VerificationToken + email are still created/sent inside the same transaction.
- Login: fetches verified field and returns 403 email_not_verified if the account has not been verified yet.
- verify-email route: already correct — sets verified=true and emailVerifiedAt, deletes the token.
- circles/[id]/join POST: guards with verified check (403 if not verified), consistent with the existing guard in ajos/route.ts.
- No schema migration needed: User.verified Boolean @default(false) and VerificationToken model already exist.

Closes #601