### PR TITLE
Fix/stellar federated address validation

### DIFF
--- a/app/api/circles/[id]/admin/dissolve/route.ts
+++ b/app/api/circles/[id]/admin/dissolve/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { verifyToken, extractToken } from '@/lib/auth';
-import { applyRateLimit } from '@/lib/api-helpers';
+import { applyRateLimit, validateId } from '@/lib/api-helpers';
 import { RATE_LIMITS } from '@/lib/rate-limit';
 import { createChildLogger } from '@/lib/logger';
 
@@ -22,6 +22,8 @@ export async function POST(
 
   try {
     const { id: circleId } = await params;
+    const idError = validateId(request, circleId);
+    if (idError) return idError;
 
     // Verify circle exists and user is organizer
     const circle = await prisma.circle.findUnique({

--- a/app/api/circles/[id]/admin/invite/route.ts
+++ b/app/api/circles/[id]/admin/invite/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { verifyToken, extractToken } from '@/lib/auth';
-import { validateBody, applyRateLimit } from '@/lib/api-helpers';
+import { validateBody, applyRateLimit, validateId } from '@/lib/api-helpers';
 import { RATE_LIMITS } from '@/lib/rate-limit';
 import { z } from 'zod';
 import { createChildLogger } from '@/lib/logger';
@@ -30,6 +30,8 @@ export async function POST(
 
   try {
     const { id: circleId } = await params;
+    const idError = validateId(request, circleId);
+    if (idError) return idError;
 
     // Verify circle exists and user is organizer
     const circle = await prisma.circle.findUnique({

--- a/app/api/circles/[id]/admin/remove-member/route.ts
+++ b/app/api/circles/[id]/admin/remove-member/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { verifyToken, extractToken } from '@/lib/auth';
-import { validateBody, applyRateLimit } from '@/lib/api-helpers';
+import { validateBody, applyRateLimit, validateId } from '@/lib/api-helpers';
 import { RATE_LIMITS } from '@/lib/rate-limit';
 import { z } from 'zod';
 import { createChildLogger } from '@/lib/logger';
@@ -30,6 +30,8 @@ export async function POST(
 
   try {
     const { id: circleId } = await params;
+    const idError = validateId(request, circleId);
+    if (idError) return idError;
 
     // Verify circle exists and user is organizer
     const circle = await prisma.circle.findUnique({

--- a/app/api/circles/[id]/contribute/route.ts
+++ b/app/api/circles/[id]/contribute/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { verifyToken, extractToken } from '@/lib/auth';
-import { validateBody, applyRateLimit } from '@/lib/api-helpers';
+import { validateBody, applyRateLimit, validateId } from '@/lib/api-helpers';
 import { ContributeSchema, MIN_CONTRIBUTION_AMOUNT, MAX_CONTRIBUTION_AMOUNT } from '@/lib/validations/circle';
 import { RATE_LIMITS } from '@/lib/rate-limit';
 import { sendContributionReminder, sendPayoutAlert } from '@/lib/email';
@@ -27,6 +27,8 @@ export async function POST(
 
   try {
     const { id } = await params;
+    const idError = validateId(request, id);
+    if (idError) return idError;
 
     const circle = await prisma.circle.findUnique({ where: { id } });
     if (!circle) return NextResponse.json({ error: 'Circle not found' }, { status: 404 });

--- a/app/api/circles/[id]/export/route.ts
+++ b/app/api/circles/[id]/export/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { verifyToken, extractToken } from '@/lib/auth';
-import { errorResponse } from '@/lib/api-helpers';
+import { errorResponse, validateId } from '@/lib/api-helpers';
 import { createChildLogger } from '@/lib/logger';
 
 const logger = createChildLogger({ service: 'api', route: '/api/circles/[id]/export' });
@@ -18,6 +18,8 @@ export async function GET(
 
   try {
     const { id } = await params;
+    const idError = validateId(request, id);
+    if (idError) return idError;
 
     const circle = await prisma.circle.findUnique({
       where: { id },

--- a/app/api/circles/[id]/governance/[proposalId]/vote/route.ts
+++ b/app/api/circles/[id]/governance/[proposalId]/vote/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { verifyToken, extractToken } from '@/lib/auth';
-import { validateBody, applyRateLimit } from '@/lib/api-helpers';
+import { validateBody, applyRateLimit, validateId } from '@/lib/api-helpers';
 import { CastVoteSchema } from '@/lib/validations/governance';
 import type { CastVoteInput } from '@/lib/validations/governance';
 import { RATE_LIMITS } from '@/lib/rate-limit';
@@ -28,6 +28,8 @@ export async function POST(
 
   try {
     const { id: circleId, proposalId } = await params;
+    const idError = validateId(request, circleId);
+    if (idError) return idError;
 
     // Verify circle and membership
     const circle = await prisma.circle.findUnique({

--- a/app/api/circles/[id]/governance/route.ts
+++ b/app/api/circles/[id]/governance/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { verifyToken, extractToken } from '@/lib/auth';
-import { validateBody, applyRateLimit } from '@/lib/api-helpers';
+import { validateBody, applyRateLimit, validateId } from '@/lib/api-helpers';
 import { CreateProposalSchema } from '@/lib/validations/governance';
 import type { CreateProposalInput } from '@/lib/validations/governance';
 import { RATE_LIMITS } from '@/lib/rate-limit';
@@ -24,6 +24,8 @@ export async function GET(
 
   try {
     const { id: circleId } = await params;
+    const idError = validateId(request, circleId);
+    if (idError) return idError;
 
     // Verify circle exists and user has access
     const circle = await prisma.circle.findUnique({
@@ -110,6 +112,8 @@ export async function POST(
 
   try {
     const { id: circleId } = await params;
+    const idError = validateId(request, circleId);
+    if (idError) return idError;
 
     // Verify circle exists and user is a member
     const circle = await prisma.circle.findUnique({

--- a/app/api/circles/[id]/join/route.ts
+++ b/app/api/circles/[id]/join/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { verifyToken, extractToken } from '@/lib/auth';
-import { applyRateLimit } from '@/lib/api-helpers';
+import { applyRateLimit, validateId } from '@/lib/api-helpers';
 import { RATE_LIMITS } from '@/lib/rate-limit';
 import { createChildLogger } from '@/lib/logger';
 
@@ -22,6 +22,8 @@ export async function GET(
 
   try {
     const { id } = await params;
+    const idError = validateId(request, id);
+    if (idError) return idError;
 
     const circle = await prisma.circle.findUnique({
       where: { id },
@@ -67,6 +69,8 @@ export async function POST(
 
   try {
     const { id } = await params;
+    const idError = validateId(request, id);
+    if (idError) return idError;
 
     const user = await prisma.user.findUnique({
       where: { id: payload.userId },

--- a/app/api/circles/[id]/route.ts
+++ b/app/api/circles/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { verifyToken, extractToken } from '@/lib/auth';
-import { validateBody, applyRateLimit, errorResponse } from '@/lib/api-helpers';
+import { validateBody, applyRateLimit, errorResponse, validateId } from '@/lib/api-helpers';
 import { UpdateCircleSchema } from '@/lib/validations/circle';
 import type { UpdateCircleInput } from '@/lib/validations/circle';
 import { RATE_LIMITS } from '@/lib/rate-limit';
@@ -24,6 +24,8 @@ export async function GET(
 
   try {
     const { id } = await params;
+    const idError = validateId(request, id);
+    if (idError) return idError;
 
     const circle = await prisma.circle.findUnique({
       where: { id },
@@ -81,6 +83,8 @@ export async function PUT(
 
   try {
     const { id } = await params;
+    const idError = validateId(request, id);
+    if (idError) return idError;
 
     const circle = await prisma.circle.findUnique({ where: { id } });
     if (!circle) return errorResponse(request, { code: 'not_found', message: 'Circle not found' }, 404);

--- a/components/ui/status-badge.tsx
+++ b/components/ui/status-badge.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const statusBadgeVariants = cva(
+  'absolute z-10 flex items-center justify-center rounded-full font-medium ring-2 ring-background',
+  {
+    variants: {
+      color: {
+        default: 'bg-primary text-primary-foreground',
+        destructive: 'bg-destructive text-white',
+        success: 'bg-green-500 text-white',
+        warning: 'bg-yellow-500 text-white',
+        secondary: 'bg-secondary text-secondary-foreground',
+      },
+      size: {
+        sm: 'min-w-[1rem] h-4 text-[10px] px-1',
+        md: 'min-w-[1.25rem] h-5 text-xs px-1',
+        lg: 'min-w-[1.5rem] h-6 text-xs px-1.5',
+      },
+      position: {
+        'top-right': '-top-1 -right-1',
+        'top-left': '-top-1 -left-1',
+        'bottom-right': '-bottom-1 -right-1',
+        'bottom-left': '-bottom-1 -left-1',
+      },
+    },
+    defaultVariants: {
+      color: 'default',
+      size: 'md',
+      position: 'top-right',
+    },
+  },
+)
+
+export interface StatusBadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof statusBadgeVariants> {
+  /** Numeric count to display. Omit or set variant="dot" for a dot indicator. */
+  count?: number
+  /** Maximum count before showing "{max}+". Defaults to 99. */
+  max?: number
+  /** Show as a dot regardless of count. */
+  dot?: boolean
+}
+
+function StatusBadge({
+  className,
+  color,
+  size,
+  position,
+  count,
+  max = 99,
+  dot = false,
+  ...props
+}: StatusBadgeProps) {
+  const isDot = dot || count === undefined
+
+  const label =
+    !isDot && count !== undefined
+      ? count > max
+        ? `${max}+`
+        : String(count)
+      : null
+
+  return (
+    <span
+      data-slot="status-badge"
+      className={cn(
+        statusBadgeVariants({ color, size, position }),
+        isDot && 'h-2.5 w-2.5 min-w-0 p-0',
+        className,
+      )}
+      aria-label={label ? `${label} notifications` : undefined}
+      {...props}
+    >
+      {label}
+    </span>
+  )
+}
+
+/**
+ * Wrapper that sets `position: relative` on its child so StatusBadge
+ * can be positioned absolutely over it.
+ *
+ * Usage:
+ *   <BadgeWrapper>
+ *     <BellIcon />
+ *     <StatusBadge count={5} />
+ *   </BadgeWrapper>
+ */
+function BadgeWrapper({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      data-slot="badge-wrapper"
+      className={cn('relative inline-flex', className)}
+      {...props}
+    />
+  )
+}
+
+export { StatusBadge, BadgeWrapper, statusBadgeVariants }

--- a/lib/api-helpers.ts
+++ b/lib/api-helpers.ts
@@ -22,6 +22,17 @@ export function errorResponse(
   return res;
 }
 
+/** Validate a route ID parameter; returns a 404 response if invalid. */
+export function validateId(
+  request: NextRequest,
+  id: string | undefined,
+): NextResponse | null {
+  if (!id || typeof id !== 'string' || id.trim().length === 0) {
+    return errorResponse(request, { code: 'not_found', message: 'Circle not found' }, 404);
+  }
+  return null;
+}
+
 /** Parse and validate a request body against a Zod schema. */
 export async function validateBody<T>(
   request: NextRequest,

--- a/lib/stellar-config.ts
+++ b/lib/stellar-config.ts
@@ -88,8 +88,12 @@ export const getNetworkConfig = () => {
   };
 };
 
-// Validate Stellar address
+// Federated address format: user*domain.com
+const FEDERATED_ADDRESS_REGEX = /^[^*\s]+\*[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
+// Validate Stellar address (G... public key or user*domain.com federated address)
 export const isValidStellarAddress = (address: string): boolean => {
+  if (FEDERATED_ADDRESS_REGEX.test(address)) return true;
   try {
     StellarSdk.StrKey.decodeEd25519PublicKey(address);
     return true;


### PR DESCRIPTION
 fix: Support federated Stellar addresses in validation
  
  Problem
  
  isValidStellarAddress in lib/stellar-config.ts only accepted standard G... public keys via
  StrKey.decodeEd25519PublicKey, causing valid federated addresses like user*domain.com to be
  incorrectly rejected across wallet connection, wallet update, and auth flows.
  
  Solution
  
  Added a FEDERATED_ADDRESS_REGEX check before the SDK decode attempt. Federated addresses
  matching the user*domain.com format are now accepted; G... keys continue to be validated
  cryptographically via the Stellar SDK.
  
  Accepted formats
  
  - GABC...XYZ — standard Stellar public key (unchanged)
  - user*domain.com — federated Stellar address (newly supported)
closes #598