### PR TITLE
feat: implement bulk user registration endpoint

### DIFF
--- a/__tests__/api/bulk-registration.test.ts
+++ b/__tests__/api/bulk-registration.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Test suite for bulk user registration
+ * Closes #593
+ */
+
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/auth/register/bulk/route';
+import { prisma } from '@/lib/prisma';
+import { hashPassword } from '@/lib/auth';
+
+// Mock dependencies
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findMany: jest.fn(),
+      createMany: jest.fn(),
+    },
+    verificationToken: {
+      createMany: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/auth', () => ({
+  hashPassword: jest.fn((password) => Promise.resolve(`hashed_${password}`)),
+  validatePasswordStrength: jest.fn(() => ({ isValid: true, errors: [] })),
+}));
+
+jest.mock('@/lib/email', () => ({
+  sendVerificationEmail: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/lib/api-helpers', () => ({
+  validateBody: jest.fn(async (request, schema) => {
+    const body = await request.json();
+    try {
+      const data = schema.parse(body);
+      return { data, error: null };
+    } catch (err: any) {
+      return {
+        data: null,
+        error: { json: () => ({ error: err.message }), status: 400 },
+      };
+    }
+  }),
+  applyRateLimit: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  createChildLogger: jest.fn(() => ({
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  })),
+}));
+
+describe('POST /api/auth/register/bulk - Bulk Registration (Issue #593)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should successfully register multiple users at once', async () => {
+    const users = [
+      {
+        email: 'user1@example.com',
+        password: 'Password123!',
+        firstName: 'User',
+        lastName: 'One',
+      },
+      {
+        email: 'user2@example.com',
+        password: 'Password123!',
+        firstName: 'User',
+        lastName: 'Two',
+      },
+      {
+        email: 'user3@example.com',
+        password: 'Password123!',
+        firstName: 'User',
+        lastName: 'Three',
+      },
+    ];
+
+    // Mock no existing users
+    (prisma.user.findMany as jest.Mock).mockResolvedValue([]);
+
+    // Mock transaction
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback) => {
+      return callback({
+        user: {
+          createMany: jest.fn().mockResolvedValue({ count: 3 }),
+          findMany: jest.fn().mockResolvedValue([
+            { id: 'user-1', email: 'user1@example.com', firstName: 'User', lastName: 'One' },
+            { id: 'user-2', email: 'user2@example.com', firstName: 'User', lastName: 'Two' },
+            { id: 'user-3', email: 'user3@example.com', firstName: 'User', lastName: 'Three' },
+          ]),
+        },
+        verificationToken: {
+          createMany: jest.fn().mockResolvedValue({ count: 3 }),
+        },
+      });
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/auth/register/bulk', {
+      method: 'POST',
+      body: JSON.stringify({ users }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.summary).toEqual({
+      total: 3,
+      successful: 3,
+      failed: 0,
+    });
+    expect(data.results).toHaveLength(3);
+    expect(data.results.every((r: any) => r.success)).toBe(true);
+  });
+
+  it('should return summary of successful and failed registrations', async () => {
+    const users = [
+      {
+        email: 'new@example.com',
+        password: 'Password123!',
+        firstName: 'New',
+        lastName: 'User',
+      },
+      {
+        email: 'existing@example.com',
+        password: 'Password123!',
+        firstName: 'Existing',
+        lastName: 'User',
+      },
+    ];
+
+    // Mock one existing user
+    (prisma.user.findMany as jest.Mock).mockResolvedValue([
+      { email: 'existing@example.com' },
+    ]);
+
+    // Mock transaction for the new user
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback) => {
+      return callback({
+        user: {
+          createMany: jest.fn().mockResolvedValue({ count: 1 }),
+          findMany: jest.fn().mockResolvedValue([
+            { id: 'user-1', email: 'new@example.com', firstName: 'New', lastName: 'User' },
+          ]),
+        },
+        verificationToken: {
+          createMany: jest.fn().mockResolvedValue({ count: 1 }),
+        },
+      });
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/auth/register/bulk', {
+      method: 'POST',
+      body: JSON.stringify({ users }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.summary).toEqual({
+      total: 2,
+      successful: 1,
+      failed: 1,
+    });
+
+    const failedResult = data.results.find((r: any) => r.email === 'existing@example.com');
+    expect(failedResult.success).toBe(false);
+    expect(failedResult.error).toContain('already exists');
+
+    const successResult = data.results.find((r: any) => r.email === 'new@example.com');
+    expect(successResult.success).toBe(true);
+    expect(successResult.userId).toBeDefined();
+  });
+
+  it('should use prisma.user.createMany for efficient insertion', async () => {
+    const users = [
+      {
+        email: 'bulk1@example.com',
+        password: 'Password123!',
+        firstName: 'Bulk',
+        lastName: 'One',
+      },
+      {
+        email: 'bulk2@example.com',
+        password: 'Password123!',
+        firstName: 'Bulk',
+        lastName: 'Two',
+      },
+    ];
+
+    (prisma.user.findMany as jest.Mock).mockResolvedValue([]);
+
+    const mockCreateMany = jest.fn().mockResolvedValue({ count: 2 });
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback) => {
+      return callback({
+        user: {
+          createMany: mockCreateMany,
+          findMany: jest.fn().mockResolvedValue([
+            { id: 'user-1', email: 'bulk1@example.com', firstName: 'Bulk', lastName: 'One' },
+            { id: 'user-2', email: 'bulk2@example.com', firstName: 'Bulk', lastName: 'Two' },
+          ]),
+        },
+        verificationToken: {
+          createMany: jest.fn().mockResolvedValue({ count: 2 }),
+        },
+      });
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/auth/register/bulk', {
+      method: 'POST',
+      body: JSON.stringify({ users }),
+    });
+
+    await POST(request);
+
+    expect(mockCreateMany).toHaveBeenCalledWith({
+      data: expect.arrayContaining([
+        expect.objectContaining({
+          email: 'bulk1@example.com',
+          password: expect.stringContaining('hashed_'),
+        }),
+        expect.objectContaining({
+          email: 'bulk2@example.com',
+          password: expect.stringContaining('hashed_'),
+        }),
+      ]),
+      skipDuplicates: true,
+    });
+  });
+
+  it('should reject requests with more than 100 users', async () => {
+    const users = Array.from({ length: 101 }, (_, i) => ({
+      email: `user${i}@example.com`,
+      password: 'Password123!',
+      firstName: 'User',
+      lastName: `${i}`,
+    }));
+
+    const request = new NextRequest('http://localhost:3000/api/auth/register/bulk', {
+      method: 'POST',
+      body: JSON.stringify({ users }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBeDefined();
+  });
+
+  it('should validate each user email format', async () => {
+    const users = [
+      {
+        email: 'invalid-email',
+        password: 'Password123!',
+        firstName: 'Invalid',
+        lastName: 'Email',
+      },
+    ];
+
+    const request = new NextRequest('http://localhost:3000/api/auth/register/bulk', {
+      method: 'POST',
+      body: JSON.stringify({ users }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBeDefined();
+  });
+
+  it('should handle partial failures gracefully', async () => {
+    const users = [
+      {
+        email: 'valid@example.com',
+        password: 'Password123!',
+        firstName: 'Valid',
+        lastName: 'User',
+      },
+      {
+        email: 'existing@example.com',
+        password: 'Password123!',
+        firstName: 'Existing',
+        lastName: 'User',
+      },
+    ];
+
+    (prisma.user.findMany as jest.Mock).mockResolvedValue([
+      { email: 'existing@example.com' },
+    ]);
+
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback) => {
+      return callback({
+        user: {
+          createMany: jest.fn().mockResolvedValue({ count: 1 }),
+          findMany: jest.fn().mockResolvedValue([
+            { id: 'user-1', email: 'valid@example.com', firstName: 'Valid', lastName: 'User' },
+          ]),
+        },
+        verificationToken: {
+          createMany: jest.fn().mockResolvedValue({ count: 1 }),
+        },
+      });
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/auth/register/bulk', {
+      method: 'POST',
+      body: JSON.stringify({ users }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.summary.successful).toBe(1);
+    expect(data.summary.failed).toBe(1);
+    expect(data.results).toHaveLength(2);
+  });
+
+  it('should require at least one user in the request', async () => {
+    const request = new NextRequest('http://localhost:3000/api/auth/register/bulk', {
+      method: 'POST',
+      body: JSON.stringify({ users: [] }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBeDefined();
+  });
+});

--- a/app/api/auth/register/bulk/route.ts
+++ b/app/api/auth/register/bulk/route.ts
@@ -1,0 +1,214 @@
+/**
+ * Bulk user registration endpoint
+ * Closes #593
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import crypto from 'crypto';
+import { z } from 'zod';
+import { prisma } from '@/lib/prisma';
+import { hashPassword, validatePasswordStrength } from '@/lib/auth';
+import { validateBody, applyRateLimit } from '@/lib/api-helpers';
+import { RATE_LIMITS } from '@/lib/rate-limit';
+import { createChildLogger } from '@/lib/logger';
+import { sendVerificationEmail } from '@/lib/email';
+
+const logger = createChildLogger({ service: 'api', route: '/api/auth/register/bulk' });
+
+// Schema for a single user in bulk registration
+const BulkUserSchema = z.object({
+  email: z.string().email('Invalid email format'),
+  password: z.string().min(8, 'Password must be at least 8 characters'),
+  firstName: z.string().min(1, 'First name is required'),
+  lastName: z.string().min(1, 'Last name is required'),
+});
+
+// Schema for bulk registration request
+const BulkRegisterSchema = z.object({
+  users: z.array(BulkUserSchema).min(1, 'At least one user is required').max(100, 'Maximum 100 users per request'),
+});
+
+type BulkUserInput = z.infer<typeof BulkUserSchema>;
+
+interface RegistrationResult {
+  email: string;
+  success: boolean;
+  error?: string;
+  userId?: string;
+}
+
+export async function POST(request: NextRequest) {
+  // Apply rate limiting (stricter for bulk operations)
+  const rateLimited = await applyRateLimit(request, RATE_LIMITS.auth, 'auth:register:bulk');
+  if (rateLimited) return rateLimited;
+
+  const { data, error } = await validateBody(request, BulkRegisterSchema);
+  if (error) return error;
+
+  const { users } = data as z.infer<typeof BulkRegisterSchema>;
+
+  const results: RegistrationResult[] = [];
+  const successfulRegistrations: Array<{ email: string; token: string }> = [];
+
+  try {
+    // Validate all passwords first
+    for (const user of users) {
+      const passwordValidation = validatePasswordStrength(user.password);
+      if (!passwordValidation.isValid) {
+        results.push({
+          email: user.email,
+          success: false,
+          error: `Password does not meet strength requirements: ${passwordValidation.errors.join(', ')}`,
+        });
+      }
+    }
+
+    // Filter out users with invalid passwords
+    const validUsers = users.filter(
+      (user) => !results.find((r) => r.email === user.email && !r.success)
+    );
+
+    // Check for existing users
+    const emails = validUsers.map((u) => u.email.toLowerCase());
+    const existingUsers = await prisma.user.findMany({
+      where: { email: { in: emails } },
+      select: { email: true },
+    });
+
+    const existingEmails = new Set(existingUsers.map((u) => u.email));
+
+    // Mark existing users as failed
+    for (const user of validUsers) {
+      if (existingEmails.has(user.email.toLowerCase())) {
+        results.push({
+          email: user.email,
+          success: false,
+          error: 'User with this email already exists',
+        });
+      }
+    }
+
+    // Filter to only new users
+    const newUsers = validUsers.filter((user) => !existingEmails.has(user.email.toLowerCase()));
+
+    if (newUsers.length === 0) {
+      return NextResponse.json(
+        {
+          message: 'No new users to register',
+          results,
+          summary: {
+            total: users.length,
+            successful: 0,
+            failed: results.length,
+          },
+        },
+        { status: 400 }
+      );
+    }
+
+    // Hash passwords for all new users
+    const usersWithHashedPasswords = await Promise.all(
+      newUsers.map(async (user) => ({
+        email: user.email.toLowerCase(),
+        password: await hashPassword(user.password),
+        firstName: user.firstName,
+        lastName: user.lastName,
+      }))
+    );
+
+    // Use transaction to create users and verification tokens
+    const createdUsers = await prisma.$transaction(async (tx: any) => {
+      // Create all users at once using createMany
+      await tx.user.createMany({
+        data: usersWithHashedPasswords,
+        skipDuplicates: true,
+      });
+
+      // Fetch the created users to get their IDs
+      const created = await tx.user.findMany({
+        where: {
+          email: { in: usersWithHashedPasswords.map((u) => u.email) },
+        },
+        select: {
+          id: true,
+          email: true,
+          firstName: true,
+          lastName: true,
+        },
+      });
+
+      // Create verification tokens for all users
+      const verificationTokens = created.map((user) => ({
+        token: crypto.randomBytes(32).toString('hex'),
+        userId: user.id,
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours
+      }));
+
+      await tx.verificationToken.createMany({
+        data: verificationTokens,
+      });
+
+      return created.map((user, index) => ({
+        ...user,
+        verificationToken: verificationTokens[index].token,
+      }));
+    });
+
+    // Add successful registrations to results
+    for (const user of createdUsers) {
+      results.push({
+        email: user.email,
+        success: true,
+        userId: user.id,
+      });
+
+      successfulRegistrations.push({
+        email: user.email,
+        token: user.verificationToken,
+      });
+    }
+
+    // Send verification emails asynchronously (don't block response)
+    Promise.all(
+      successfulRegistrations.map(({ email, token }) =>
+        sendVerificationEmail(email, token).catch((err) => {
+          logger.error('Failed to send verification email during bulk registration', {
+            err,
+            email,
+          });
+        })
+      )
+    ).catch((err) => {
+      logger.error('Error sending bulk verification emails', { err });
+    });
+
+    const summary = {
+      total: users.length,
+      successful: results.filter((r) => r.success).length,
+      failed: results.filter((r) => !r.success).length,
+    };
+
+    return NextResponse.json(
+      {
+        message: `Bulk registration completed. ${summary.successful} successful, ${summary.failed} failed.`,
+        results,
+        summary,
+      },
+      { status: 201 }
+    );
+  } catch (err) {
+    logger.error('Bulk registration error', { err });
+    return NextResponse.json(
+      {
+        error: 'Internal server error during bulk registration',
+        results,
+        summary: {
+          total: users.length,
+          successful: results.filter((r) => r.success).length,
+          failed: users.length - results.filter((r) => r.success).length,
+        },
+      },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
- Add /api/auth/register/bulk endpoint for batch user creation
- Use prisma.user.createMany for efficient bulk insertion
- Return detailed summary of successful and failed registrations
- Support up to 100 users per request
- Validate all users before processing
- Handle partial failures gracefully
- Add comprehensive test suite

Closes #593