### PR TITLE
feat(storage): implement lazy loading for member data (#671)

### DIFF
--- a/contracts/ajo-circle/src/lib.rs
+++ b/contracts/ajo-circle/src/lib.rs
@@ -12,15 +12,15 @@ mod deposit_tests;
 mod withdrawal_tests;
 
 #[cfg(test)]
+mod penalty_tests;
+
+#[cfg(test)]
 mod test;
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, Env, Map,
     Symbol, Vec, BytesN,
 };
-
-
-
 
 pub const MAX_MEMBERS: u32 = 50;
 pub const HARD_CAP: u32 = 100;
@@ -40,108 +40,69 @@ const MANAGER_ROLE: Symbol = symbol_short!("MANAGER");
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum AjoError {
-    /// Requested resource does not exist
     NotFound = 1,
-    /// Caller lacks permission for this operation
     Unauthorized = 2,
-    /// Resource already exists (e.g., duplicate member)
     AlreadyExists = 3,
-    /// Invalid parameter provided
     InvalidInput = 4,
-    /// Member has already received their payout for this round
     AlreadyPaid = 5,
-    /// Insufficient balance for withdrawal
     InsufficientFunds = 6,
-    /// Member is disqualified due to missed contributions
     Disqualified = 7,
-    /// A dissolution vote is already in progress
     VoteAlreadyActive = 8,
-    /// No active dissolution vote exists
     NoActiveVote = 9,
-    /// Member has already cast their vote
     AlreadyVoted = 10,
-    /// Circle is not in the required state for this operation
     CircleNotActive = 11,
-    /// Circle has already been dissolved
     CircleAlreadyDissolved = 12,
-    /// Circle has reached maximum member capacity
     CircleAtCapacity = 13,
-    /// Circle is in emergency panic state
     CirclePanicked = 14,
-    /// Oracle price data is unavailable
     PriceUnavailable = 15,
-    /// Arithmetic operation would overflow
     ArithmeticOverflow = 16,
-        Paused = 17,
+    Paused = 17,
 }
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CircleData {
-    /// Address of the circle organizer (admin)
     pub organizer: Address,
-    /// Token contract address (e.g., USDC, XLM)
     pub token_address: Address,
-    /// Required contribution amount per round
     pub contribution_amount: i128,
-    /// Duration of each round in days
     pub frequency_days: u32,
-    /// Total number of rounds in the circle lifecycle
     pub max_rounds: u32,
-    /// Current active round number (1-indexed)
     pub current_round: u32,
-    /// Current number of active members
     pub member_count: u32,
-    /// Maximum allowed members
     pub max_members: u32,
 }
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MemberData {
-    /// Member's wallet address
     pub address: Address,
-    /// Cumulative amount contributed to the circle
     pub total_contributed: i128,
-    /// Cumulative amount withdrawn from the circle
     pub total_withdrawn: i128,
-    /// Whether member has received their scheduled payout
     pub has_received_payout: bool,
-    /// Member status: 0 = Active, 1 = Inactive, 2 = Exited
     pub status: u32,
 }
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CircleStatus {
-    /// Normal operation - contributions and payouts active
     Active,
-    /// Dissolution vote in progress
     VotingForDissolution,
-    /// Circle dissolved via governance vote
     Dissolved,
-    /// Emergency state - only refunds allowed
     Panicked,
 }
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DissolutionVote {
-    /// Number of votes in favor of dissolution
     pub votes_for: u32,
-    /// Total number of eligible voting members
     pub total_members: u32,
-    /// 0 = simple majority (>50%), 1 = supermajority (>66%)
     pub threshold_mode: u32,
 }
 
-/// Member standing and activity tracking
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MemberStanding {
-    /// Number of consecutive missed contribution rounds
     pub missed_count: u32,
-    /// Whether member is currently active (not disqualified)
     pub is_active: bool,
 }
 
@@ -155,22 +116,27 @@ pub struct FeeConfig {
 #[contracttype]
 pub enum DataKey {
     Circle,
+    /// Vec<Address> — ordered member list (used for iteration/shuffle only)
     Members,
-    Standings,
     Admin,
-    KycStatus,
     CircleStatus,
     RotationOrder,
     RoundDeadline,
     RoundContribCount,
     TotalPool,
-    LastDepositAt,
     CycleWithdrawals,
     RoleMembers,
     Deployer,
     FeeConfig,
-    /// Tracks addresses that have already cast a dissolution vote
     VotedMembers,
+    /// Per-member data — O(1) direct access
+    Member(Address),
+    /// Per-member standing — O(1) direct access
+    Standing(Address),
+    /// Per-member last deposit timestamp — O(1) direct access
+    LastDeposit(Address),
+    /// Per-member KYC status — O(1) direct access
+    KycVerified(Address),
 }
 
 #[contract]
@@ -179,15 +145,12 @@ pub struct AjoCircle;
 #[contractimpl]
 impl AjoCircle {
     // ---------------- INTERNAL HELPERS ----------------
-    
-    /// Deterministic Fisher-Yates shuffle using a simple LCG.
-    /// This is a pure function, invariant and bijective.
+
     fn deterministic_shuffle<T>(list: &mut [T], mut seed: u64) {
         if list.is_empty() {
             return;
         }
         for i in (1..list.len()).rev() {
-            // Simple LCG: x = (a*x + c) % m
             seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
             let j = (seed % (i as u64 + 1)) as usize;
             list.swap(i, j);
@@ -221,7 +184,11 @@ impl AjoCircle {
     }
 
     fn is_paused(env: &Env) -> bool {
-        let status: CircleStatus = env.storage().instance().get(&DataKey::CircleStatus).unwrap_or(CircleStatus::Active);
+        let status: CircleStatus = env
+            .storage()
+            .instance()
+            .get(&DataKey::CircleStatus)
+            .unwrap_or(CircleStatus::Active);
         status == CircleStatus::Panicked
     }
 
@@ -233,7 +200,6 @@ impl AjoCircle {
         }
     }
 
-    /// Internal role check (no Env ownership required).
     fn has_role_internal(env: &Env, role: Symbol, member: &Address) -> bool {
         if let Some(deployer) = env.storage().instance().get::<DataKey, Address>(&DataKey::Deployer) {
             if deployer == *member {
@@ -266,27 +232,317 @@ impl AjoCircle {
         Ok(circle.contribution_amount)
     }
 
+    // ---------------- PER-MEMBER STORAGE HELPERS (O(1)) ----------------
+
+    fn load_member(env: &Env, addr: &Address) -> Result<MemberData, AjoError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Member(addr.clone()))
+            .ok_or(AjoError::NotFound)
+    }
+
+    fn save_member(env: &Env, addr: &Address, data: &MemberData) {
+        env.storage()
+            .instance()
+            .set(&DataKey::Member(addr.clone()), data);
+    }
+
+    fn member_exists(env: &Env, addr: &Address) -> bool {
+        env.storage()
+            .instance()
+            .has(&DataKey::Member(addr.clone()))
+    }
+
+    fn load_standing(env: &Env, addr: &Address) -> Result<MemberStanding, AjoError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Standing(addr.clone()))
+            .ok_or(AjoError::NotFound)
+    }
+
+    fn save_standing(env: &Env, addr: &Address, standing: &MemberStanding) {
+        env.storage()
+            .instance()
+            .set(&DataKey::Standing(addr.clone()), standing);
+    }
+
+    /// Append address to the Members list (Vec<Address>).
+    fn push_member_list(env: &Env, addr: &Address) {
+        let mut list: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Members)
+            .unwrap_or_else(|| Vec::new(env));
+        list.push_back(addr.clone());
+        env.storage().instance().set(&DataKey::Members, &list);
+    }
+
+    /// Load the full member address list (only needed for iteration).
+    fn load_member_list(env: &Env) -> Vec<Address> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Members)
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
     // ---------------- INITIALIZE ----------------
+
+    pub fn initialize_circle(
+        env: Env,
+        organizer: Address,
+        token_address: Address,
+        contribution_amount: i128,
+        frequency_days: u32,
+        max_rounds: u32,
+        max_members: u32,
+    ) -> Result<(), AjoError> {
+        organizer.require_auth();
+
+        let configured_max_members = if max_members == 0 { MAX_MEMBERS } else { max_members };
+
+        if contribution_amount < MIN_CONTRIBUTION_AMOUNT as i128
+            || contribution_amount > MAX_CONTRIBUTION_AMOUNT as i128
+            || frequency_days < MIN_FREQUENCY_DAYS
+            || frequency_days > MAX_FREQUENCY_DAYS
+            || max_rounds < MIN_ROUNDS
+            || max_rounds > MAX_ROUNDS
+            || configured_max_members == 0
+            || configured_max_members > HARD_CAP
+        {
+            return Err(AjoError::InvalidInput);
+        }
+
+        let circle_data = CircleData {
+            organizer: organizer.clone(),
+            token_address,
+            contribution_amount,
+            frequency_days,
+            max_rounds,
+            current_round: 1,
+            member_count: 1,
+            max_members: configured_max_members,
+        };
+
+        env.storage().instance().set(&DataKey::Circle, &circle_data);
+        env.storage().instance().set(&DataKey::Admin, &organizer);
+        env.storage().instance().set(&DataKey::Deployer, &organizer);
+        env.storage().instance().set(&DataKey::RoundContribCount, &0_u32);
+
+        let deadline = env.ledger().timestamp() + (frequency_days as u64) * 86_400;
+        env.storage().instance().set(&DataKey::RoundDeadline, &deadline);
+
+        // Store organizer as first member using per-member keys
+        let organizer_data = MemberData {
+            address: organizer.clone(),
+            total_contributed: 0,
+            total_withdrawn: 0,
+            has_received_payout: false,
+            status: 0,
+        };
+        Self::save_member(&env, &organizer, &organizer_data);
+        Self::save_standing(&env, &organizer, &MemberStanding { missed_count: 0, is_active: true });
+        Self::push_member_list(&env, &organizer);
+
+        Ok(())
+    }
+
+    // ---------------- MEMBERSHIP ----------------
+
+    pub fn join_circle(env: Env, organizer: Address, new_member: Address) -> Result<(), AjoError> {
+        organizer.require_auth();
+        Self::require_not_paused(&env)?;
+
+        let mut circle: CircleData = env
+            .storage()
+            .instance()
+            .get(&DataKey::Circle)
+            .ok_or(AjoError::NotFound)?;
+
+        if circle.organizer != organizer {
+            return Err(AjoError::Unauthorized);
+        }
+        if Self::member_exists(&env, &new_member) {
+            return Err(AjoError::AlreadyExists);
+        }
+        if circle.member_count >= circle.max_members {
+            return Err(AjoError::CircleAtCapacity);
+        }
+
+        Self::save_member(&env, &new_member, &MemberData {
+            address: new_member.clone(),
+            total_contributed: 0,
+            total_withdrawn: 0,
+            has_received_payout: false,
+            status: 0,
+        });
+        Self::save_standing(&env, &new_member, &MemberStanding { missed_count: 0, is_active: true });
+        Self::push_member_list(&env, &new_member);
+
+        circle.member_count = circle.member_count.checked_add(1).ok_or(AjoError::InvalidInput)?;
+        env.storage().instance().set(&DataKey::Circle, &circle);
+
+        Ok(())
+    }
+
+    pub fn add_member(env: Env, organizer: Address, new_member: Address) -> Result<(), AjoError> {
+        Self::join_circle(env, organizer, new_member)
+    }
+
+    // ---------------- CONTRIBUTIONS ----------------
+
+    pub fn contribute(env: Env, member: Address, amount: i128) -> Result<(), AjoError> {
+        member.require_auth();
+        if Self::is_paused(&env) {
+            return Err(AjoError::Paused);
+        }
+        if amount <= 0 {
+            return Err(AjoError::InvalidInput);
+        }
+
+        let mut circle: CircleData = env
+            .storage()
+            .instance()
+            .get(&DataKey::Circle)
+            .ok_or(AjoError::NotFound)?;
+
+        // O(1): load only this member's standing
+        let mut standing = Self::load_standing(&env, &member)?;
+        if standing.missed_count >= 3 || !standing.is_active {
+            return Err(AjoError::Disqualified);
+        }
+        standing.missed_count = 0;
+        Self::save_standing(&env, &member, &standing);
+
+        // O(1): load only this member's data
+        let mut member_data = Self::load_member(&env, &member)?;
+
+        let round_target = (circle.current_round as i128)
+            .checked_mul(circle.contribution_amount)
+            .ok_or(AjoError::ArithmeticOverflow)?;
+        let had_completed_round = member_data.total_contributed >= round_target;
+
+        let token_client = token::Client::new(&env, &circle.token_address);
+        token_client.transfer(&member, &env.current_contract_address(), &amount);
+
+        member_data.total_contributed = member_data
+            .total_contributed
+            .checked_add(amount)
+            .ok_or(AjoError::ArithmeticOverflow)?;
+
+        let has_completed_round = member_data.total_contributed >= round_target;
+        Self::save_member(&env, &member, &member_data);
+
+        if !had_completed_round && has_completed_round {
+            let mut round_contrib_count: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::RoundContribCount)
+                .unwrap_or(0_u32);
+
+            round_contrib_count = round_contrib_count
+                .checked_add(1)
+                .ok_or(AjoError::ArithmeticOverflow)?;
+
+            if round_contrib_count >= circle.member_count {
+                let deadline: u64 = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::RoundDeadline)
+                    .unwrap_or(0);
+                env.storage().instance().set(
+                    &DataKey::RoundDeadline,
+                    &(deadline + (circle.frequency_days as u64) * 86_400),
+                );
+                if circle.current_round < circle.max_rounds {
+                    circle.current_round += 1;
+                }
+                round_contrib_count = 0;
+                env.storage().instance().set(&DataKey::Circle, &circle);
+            }
+            env.storage().instance().set(&DataKey::RoundContribCount, &round_contrib_count);
+        }
+
+        Ok(())
+    }
+
+    pub fn deposit(env: Env, member: Address) -> Result<(), AjoError> {
+        member.require_auth();
+        if Self::is_paused(&env) {
+            return Err(AjoError::Paused);
+        }
+
+        let circle: CircleData = env
+            .storage()
+            .instance()
+            .get(&DataKey::Circle)
+            .ok_or(AjoError::NotFound)?;
+
+        let amount = circle.contribution_amount;
+        if amount <= 0 {
+            return Err(AjoError::InvalidInput);
+        }
+
+        // O(1): load only this member's standing
+        let mut standing = Self::load_standing(&env, &member)?;
+        if standing.missed_count >= 3 || !standing.is_active {
+            return Err(AjoError::Disqualified);
+        }
+        standing.missed_count = 0;
+        Self::save_standing(&env, &member, &standing);
+
+        // O(1): load only this member's data
+        let mut member_data = Self::load_member(&env, &member)?;
+
+        let token_client = token::Client::new(&env, &circle.token_address);
+        token_client.transfer(&member, &env.current_contract_address(), &amount);
+
+        member_data.total_contributed += amount;
+        Self::save_member(&env, &member, &member_data);
+
+        // O(1): record timestamp under per-member key
+        env.storage()
+            .instance()
+            .set(&DataKey::LastDeposit(member.clone()), &env.ledger().timestamp());
+
+        let mut pool: i128 = env.storage().instance().get(&DataKey::TotalPool).unwrap_or(0);
+        pool = pool.checked_add(amount).ok_or(AjoError::InvalidInput)?;
+        env.storage().instance().set(&DataKey::TotalPool, &pool);
+
+        // Check round completion by iterating the address list
+        let member_list = Self::load_member_list(&env);
+        let round_contributions = member_list
+            .iter()
+            .filter(|addr| {
+                Self::load_member(&env, &addr)
+                    .map(|m| m.total_contributed >= (circle.current_round as i128) * circle.contribution_amount)
+                    .unwrap_or(false)
+            })
+            .count() as u32;
+
+        if round_contributions >= circle.member_count {
+            let deadline: u64 = env
+                .storage()
+                .instance()
+                .get(&DataKey::RoundDeadline)
+                .unwrap_or(0);
+            env.storage().instance().set(
+                &DataKey::RoundDeadline,
+                &(deadline + (circle.frequency_days as u64) * 86_400),
+            );
+        }
+
+        env.events().publish(
+            (symbol_short!("deposit"), member.clone()),
+            (amount, circle.current_round),
+        );
+
+        Ok(())
+    }
 
     // ---------------- PAYOUT ----------------
 
-    /// Claim the rotating payout for the current cycle.
-    ///
-    /// # Security Ã¢â‚¬â€ Checks-Effects-Interactions (CEI)
-    ///
-    /// Soroban's execution model is single-threaded and does not have
-    /// Ethereum-style reentrancy, but we still follow CEI strictly:
-    ///
-    ///   CHECKS     Ã¢â‚¬â€ auth, pause, panic, member exists, not already paid,
-    ///                standing active, rotation order enforced, pool funded
-    ///   EFFECTS    Ã¢â‚¬â€ mark payout, accumulate total_withdrawn, persist state
-    ///   INTERACTIONS Ã¢â‚¬â€ token transfer executed last
-    ///
-    /// The `has_received_payout` flag is set to `true` and persisted before
-    /// the token transfer, so any hypothetical re-entry would be rejected by
-    /// the `AlreadyPaid` check.
     pub fn claim_payout(env: Env, member: Address, cycle: u32) -> Result<i128, AjoError> {
-        // Ã¢â€â‚¬Ã¢â€â‚¬ CHECKS Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
+        // CHECKS
         Self::require_not_paused(&env)?;
         member.require_auth();
 
@@ -300,33 +556,19 @@ impl AjoCircle {
             return Err(AjoError::InvalidInput);
         }
 
-        // Verify member standing
-        let standings: Map<Address, MemberStanding> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Standings)
-            .unwrap_or_else(|| Map::new(&env));
-
-        if let Some(standing) = standings.get(member.clone()) {
-            if !standing.is_active {
-                return Err(AjoError::Disqualified);
-            }
-        } else {
-            return Err(AjoError::NotFound);
+        // O(1): load only this member's standing
+        let standing = Self::load_standing(&env, &member)?;
+        if !standing.is_active {
+            return Err(AjoError::Disqualified);
         }
 
-        let mut members = Self::load_members(&env)?;
-        if members.contains_key(new_member.clone()) { return Err(AjoError::AlreadyExists); }
-        if circle.member_count >= circle.max_members { return Err(AjoError::CircleAtCapacity); }
+        // O(1): load only this member's data
+        let mut member_data = Self::load_member(&env, &member)?;
 
-        let mut member_data = members.get(member.clone()).ok_or(AjoError::NotFound)?;
-
-        // Prevent double-claim
         if member_data.has_received_payout {
             return Err(AjoError::AlreadyPaid);
         }
 
-        // Enforce rotation order when set
         if let Some(rotation) = env
             .storage()
             .instance()
@@ -339,12 +581,7 @@ impl AjoCircle {
             }
         }
 
-        // Verify pool is sufficiently funded
-        let pool: i128 = env
-            .storage()
-            .instance()
-            .get(&DataKey::TotalPool)
-            .unwrap_or(0);
+        let pool: i128 = env.storage().instance().get(&DataKey::TotalPool).unwrap_or(0);
         let required = (circle.member_count as i128)
             .checked_mul(circle.contribution_amount)
             .ok_or(AjoError::ArithmeticOverflow)?;
@@ -354,28 +591,25 @@ impl AjoCircle {
 
         let payout = required;
 
-        // Ã¢â€â‚¬Ã¢â€â‚¬ EFFECTS Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
-        // All state mutations happen BEFORE the token transfer.
+        // EFFECTS — all state before token transfer
         member_data.has_received_payout = true;
         member_data.total_withdrawn = member_data
             .total_withdrawn
             .checked_add(payout)
             .ok_or(AjoError::ArithmeticOverflow)?;
+        Self::save_member(&env, &member, &member_data);
 
-        members.set(member.clone(), member_data);
-        env.storage().instance().set(&DataKey::Members, &members);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalPool, &(pool.checked_sub(payout).ok_or(AjoError::ArithmeticOverflow)?));
 
-        // Deduct from tracked pool
-        let new_pool = pool.checked_sub(payout).ok_or(AjoError::ArithmeticOverflow)?;
-        env.storage().instance().set(&DataKey::TotalPool, &new_pool);
-
-        // Ã¢â€â‚¬Ã¢â€â‚¬ INTERACTIONS Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
+        // INTERACTIONS
         let token_client = token::Client::new(&env, &circle.token_address);
         token_client.transfer(&env.current_contract_address(), &member, &payout);
 
         env.events().publish(
             (symbol_short!("withdraw"), member.clone(), env.current_contract_address()),
-            (payout, cycle, circle.current_round)
+            (payout, cycle, circle.current_round),
         );
 
         Ok(payout)
@@ -385,11 +619,9 @@ impl AjoCircle {
         Self::claim_payout(env, member, cycle)
     }
 
-    /// Emergency partial withdrawal: exit the circle with a penalty.
     pub fn partial_withdraw(env: Env, member: Address) -> Result<i128, AjoError> {
         Self::require_not_paused(&env)?;
         member.require_auth();
-        Self::require_not_panicked(&env)?;
 
         let circle: CircleData = env
             .storage()
@@ -397,13 +629,8 @@ impl AjoCircle {
             .get(&DataKey::Circle)
             .ok_or(AjoError::NotFound)?;
 
-        let mut members: Map<Address, MemberData> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Members)
-            .ok_or(AjoError::NotFound)?;
-
-        let mut member_data = members.get(member.clone()).ok_or(AjoError::NotFound)?;
+        // O(1): load only this member's data
+        let mut member_data = Self::load_member(&env, &member)?;
 
         if member_data.total_contributed <= member_data.total_withdrawn {
             return Err(AjoError::InsufficientFunds);
@@ -415,19 +642,19 @@ impl AjoCircle {
 
         member_data.total_withdrawn += refund;
         member_data.status = 2; // Exited
-        members.set(member.clone(), member_data);
-        env.storage().instance().set(&DataKey::Members, &members);
+        Self::save_member(&env, &member, &member_data);
 
         let pool: i128 = env.storage().instance().get(&DataKey::TotalPool).unwrap_or(0);
-        let new_pool = pool.checked_sub(refund).ok_or(AjoError::ArithmeticOverflow)?;
-        env.storage().instance().set(&DataKey::TotalPool, &new_pool);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalPool, &(pool.checked_sub(refund).ok_or(AjoError::ArithmeticOverflow)?));
 
         let token_client = token::Client::new(&env, &circle.token_address);
         token_client.transfer(&env.current_contract_address(), &member, &refund);
 
         env.events().publish(
             (symbol_short!("withdraw"), member.clone(), env.current_contract_address()),
-            (refund, circle.current_round)
+            (refund, circle.current_round),
         );
 
         Ok(refund)
@@ -465,11 +692,11 @@ impl AjoCircle {
         };
 
         env.storage().instance().set(&DataKey::CircleStatus, &CircleStatus::VotingForDissolution);
-        env.storage().instance().set(&DataKey::CycleWithdrawals, &vote); // Reuse key for vote tracking
+        env.storage().instance().set(&DataKey::CycleWithdrawals, &vote);
 
         env.events().publish(
             (symbol_short!("dissolve"), symbol_short!("start"), env.current_contract_address()),
-            (threshold_mode, env.ledger().timestamp())
+            (threshold_mode, env.ledger().timestamp()),
         );
 
         Ok(())
@@ -478,12 +705,8 @@ impl AjoCircle {
     pub fn vote_to_dissolve(env: Env, member: Address) -> Result<(), AjoError> {
         member.require_auth();
 
-        let members_map: Map<Address, MemberData> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Members)
-            .ok_or(AjoError::NotFound)?;
-        if !members_map.contains_key(member.clone()) {
+        // O(1): check membership via per-member key
+        if !Self::member_exists(&env, &member) {
             return Err(AjoError::Unauthorized);
         }
 
@@ -496,7 +719,6 @@ impl AjoCircle {
         if status != CircleStatus::VotingForDissolution {
             return Err(AjoError::NoActiveVote);
         }
-        env.storage().instance().set(&DataKey::Members, &members);
 
         let mut vote: DissolutionVote = env
             .storage()
@@ -504,13 +726,12 @@ impl AjoCircle {
             .get(&DataKey::CycleWithdrawals)
             .ok_or(AjoError::NoActiveVote)?;
 
-        // Track who voted to prevent double voting
         let mut voted_members: Vec<Address> = env
             .storage()
             .instance()
             .get(&DataKey::VotedMembers)
             .unwrap_or_else(|| Vec::new(&env));
-        
+
         for i in 0..voted_members.len() {
             if voted_members.get(i).unwrap() == member {
                 return Err(AjoError::AlreadyVoted);
@@ -521,7 +742,7 @@ impl AjoCircle {
         env.storage().instance().set(&DataKey::VotedMembers, &voted_members);
 
         vote.votes_for += 1;
-        
+
         let threshold_met = if vote.threshold_mode == 0 {
             vote.votes_for * 2 > vote.total_members
         } else {
@@ -531,10 +752,9 @@ impl AjoCircle {
         if threshold_met {
             status = CircleStatus::Dissolved;
             env.storage().instance().set(&DataKey::CircleStatus, &status);
-            
             env.events().publish(
                 (symbol_short!("dissolve"), symbol_short!("passed"), env.current_contract_address()),
-                env.ledger().timestamp()
+                env.ledger().timestamp(),
             );
         } else {
             env.storage().instance().set(&DataKey::CycleWithdrawals, &vote);
@@ -542,7 +762,7 @@ impl AjoCircle {
 
         env.events().publish(
             (symbol_short!("vote_cast"), member.clone(), env.current_contract_address()),
-            (1u32, vote.votes_for) // 1 = YES
+            (1u32, vote.votes_for),
         );
 
         Ok(())
@@ -567,30 +787,23 @@ impl AjoCircle {
             .get(&DataKey::Circle)
             .ok_or(AjoError::NotFound)?;
 
-        let mut members: Map<Address, MemberData> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Members)
-            .ok_or(AjoError::NotFound)?;
-
-        let mut member_data = members.get(member.clone()).ok_or(AjoError::NotFound)?;
+        // O(1): load only this member's data
+        let mut member_data = Self::load_member(&env, &member)?;
 
         if member_data.total_contributed <= member_data.total_withdrawn {
             return Err(AjoError::InsufficientFunds);
         }
 
         let refund = member_data.total_contributed - member_data.total_withdrawn;
-        
         member_data.total_withdrawn += refund;
-        members.set(member.clone(), member_data);
-        env.storage().instance().set(&DataKey::Members, &members);
+        Self::save_member(&env, &member, &member_data);
 
         let token_client = token::Client::new(&env, &circle.token_address);
         token_client.transfer(&env.current_contract_address(), &member, &refund);
 
         env.events().publish(
             (symbol_short!("withdraw"), member.clone(), env.current_contract_address()),
-            (refund, circle.current_round)
+            (refund, circle.current_round),
         );
 
         Ok(refund)
@@ -609,30 +822,23 @@ impl AjoCircle {
             .get(&DataKey::Circle)
             .ok_or(AjoError::NotFound)?;
 
-        let mut members: Map<Address, MemberData> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Members)
-            .ok_or(AjoError::NotFound)?;
-
-        let mut member_data = members.get(member.clone()).ok_or(AjoError::NotFound)?;
+        // O(1): load only this member's data
+        let mut member_data = Self::load_member(&env, &member)?;
 
         if member_data.total_contributed <= member_data.total_withdrawn {
             return Err(AjoError::InsufficientFunds);
         }
 
         let refund = member_data.total_contributed - member_data.total_withdrawn;
-        
         member_data.total_withdrawn += refund;
-        members.set(member.clone(), member_data);
-        env.storage().instance().set(&DataKey::Members, &members);
+        Self::save_member(&env, &member, &member_data);
 
         let token_client = token::Client::new(&env, &circle.token_address);
         token_client.transfer(&env.current_contract_address(), &member, &refund);
 
         env.events().publish(
             (symbol_short!("withdraw"), member.clone(), env.current_contract_address()),
-            (refund, circle.current_round)
+            (refund, circle.current_round),
         );
 
         Ok(refund)
@@ -655,7 +861,7 @@ impl AjoCircle {
         env.storage().instance().set(&DataKey::CircleStatus, &CircleStatus::Active);
         env.events().publish(
             (symbol_short!("resume"), admin.clone(), env.current_contract_address()),
-            env.ledger().timestamp()
+            env.ledger().timestamp(),
         );
         Ok(())
     }
@@ -677,7 +883,6 @@ impl AjoCircle {
         );
         Ok(())
     }
-
 
     // ---------------- ROLE MANAGEMENT ----------------
 
@@ -712,7 +917,6 @@ impl AjoCircle {
         }
 
         env.storage().instance().set(&DataKey::RoleMembers, &role_members);
-
         env.events().publish(
             (symbol_short!("role_grnt"), new_member),
             (role, env.ledger().timestamp()),
@@ -757,7 +961,6 @@ impl AjoCircle {
             }
             role_members.set(role.clone(), updated);
             env.storage().instance().set(&DataKey::RoleMembers, &role_members);
-
             env.events().publish(
                 (symbol_short!("role_rvk"), member, env.current_contract_address()),
                 (role, env.ledger().timestamp()),
@@ -777,16 +980,10 @@ impl AjoCircle {
 
     // ---------------- QUERIES ----------------
 
-
+    /// O(1): reads only the single member's storage entry.
     pub fn get_member_balance(env: Env, member: Address) -> Result<MemberData, AjoError> {
-        let members: Map<Address, MemberData> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Members)
-            .ok_or(AjoError::NotFound)?;
-        members.get(member).ok_or(AjoError::NotFound)
+        Self::load_member(&env, &member)
     }
-
 
     pub fn get_circle_state(env: Env) -> Result<CircleData, AjoError> {
         env.storage().instance().get(&DataKey::Circle).ok_or(AjoError::NotFound)
@@ -796,407 +993,51 @@ impl AjoCircle {
         env.storage().instance().get(&DataKey::FeeConfig)
     }
 
-    /// Update the global fee configuration. Restricted to admin/deployer.
-    ///
-    /// # Security
-    /// Guarded by `require_admin` — unauthorized callers receive
-    /// `AjoError::Unauthorized`. Soroban's `require_auth()` inside
-    /// `require_admin` ensures the transaction is signed by `admin`.
-    ///
-    /// # Arguments
-    /// * `admin`       - Address of the caller (must hold ADMIN role or be deployer)
-    /// * `treasury`    - Address that receives collected fees
-    /// * `fee_bps`     - Fee in basis points (e.g. 100 = 1%). Max 1000 (10%).
     pub fn set_fee_config(
         env: Env,
         admin: Address,
         treasury: Address,
         fee_bps: u32,
     ) -> Result<(), AjoError> {
-        // ── AUTH CHECK ──────────────────────────────────────────────────────
-        // require_admin calls admin.require_auth() internally, so the tx must
-        // be signed by `admin`. Any unsigned or wrong-signer call panics here.
         Self::require_admin(&env, &admin)?;
-
-        // Sanity-check: cap fee at 10% (1000 bps) to prevent accidental drain.
         if fee_bps > 1000 {
             return Err(AjoError::InvalidInput);
         }
-
         let config = FeeConfig { treasury, fee_bps };
         env.storage().instance().set(&DataKey::FeeConfig, &config);
-
         env.events().publish(
             (symbol_short!("fee_set"), admin),
             (fee_bps, env.ledger().timestamp()),
         );
-
         Ok(())
     }
 
-    /// Calculate 10^exp with overflow checking
-    ///
-    /// # Arguments
-    /// * `exp` - Exponent value
-    ///
-    /// # Returns
-    /// * `Ok(i128)` - Result of 10^exp
-    /// * `Err(AjoError::ArithmeticOverflow)` if overflow occurs
     fn pow10_checked(exp: u32) -> Result<i128, AjoError> {
         let mut result: i128 = 1;
         let mut i: u32 = 0;
         while i < exp {
-            result = result
-                .checked_mul(10)
-                .ok_or(AjoError::ArithmeticOverflow)?;
+            result = result.checked_mul(10).ok_or(AjoError::ArithmeticOverflow)?;
             i += 1;
         }
         Ok(result)
     }
 
-    /// Initialize a new Ajo circle
-    ///
-    /// Creates a new savings circle with specified parameters. The organizer
-    /// becomes the first member and administrator.
-    ///
-    /// # Arguments
-    /// * `env` - Contract environment
-    /// * `organizer` - Address of the circle creator (becomes admin)
-    /// * `token_address` - Address of the token contract to use (e.g., USDC)
-    /// * `contribution_amount` - Required contribution per round
-    /// * `frequency_days` - Duration of each round in days
-    /// * `max_rounds` - Total number of rounds in the circle
-    /// * `max_members` - Maximum number of members (0 = use default)
-    ///
-    /// # Returns
-    /// * `Ok(())` on success
-    /// * `Err(AjoError::InvalidInput)` if parameters are invalid
-    ///
-    /// # Requirements
-    /// - Caller must be the organizer
-    /// - All numeric parameters must be positive
-    /// - max_members must not exceed HARD_CAP
-    pub fn initialize_circle(
-        env: Env,
-        organizer: Address,
-        token_address: Address,
-        contribution_amount: i128,
-        frequency_days: u32,
-        max_rounds: u32,
-        max_members: u32,
-    ) -> Result<(), AjoError> {
+    pub fn get_total_pool(env: Env) -> i128 {
+        env.storage().instance().get(&DataKey::TotalPool).unwrap_or(0)
+    }
+
+    /// O(1): reads only this member's timestamp entry.
+    pub fn get_last_deposit_timestamp(env: Env, member: Address) -> Result<u64, AjoError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::LastDeposit(member))
+            .ok_or(AjoError::NotFound)
+    }
+
+    // ---------------- SHUFFLE ----------------
+
+    pub fn shuffle_rotation(env: Env, organizer: Address) -> Result<(), AjoError> {
         organizer.require_auth();
-
-        let configured_max_members = if max_members == 0 {
-            MAX_MEMBERS
-        } else {
-            max_members
-        };
-
-        if contribution_amount < MIN_CONTRIBUTION_AMOUNT as i128
-            || contribution_amount > MAX_CONTRIBUTION_AMOUNT as i128
-            || frequency_days < MIN_FREQUENCY_DAYS
-            || frequency_days > MAX_FREQUENCY_DAYS
-            || max_rounds < MIN_ROUNDS
-            || max_rounds > MAX_ROUNDS
-            || configured_max_members == 0
-            || configured_max_members > HARD_CAP
-        {
-            return Err(AjoError::InvalidInput);
-        }
-
-        let circle_data = CircleData {
-            organizer: organizer.clone(),
-            token_address,
-            contribution_amount,
-            frequency_days,
-            max_rounds,
-            current_round: 1,
-            member_count: 1,
-            max_members: configured_max_members,
-        };
-
-        env.storage().instance().set(&DataKey::Circle, &circle_data);
-        env.storage().instance().set(&DataKey::Admin, &organizer);
-        // Store organizer as the deployer/owner so require_admin and
-        // require_deployer guards are functional from the first call onward.
-        env.storage().instance().set(&DataKey::Deployer, &organizer);
-        env.storage().instance().set(&DataKey::RoundContribCount, &0_u32);
-
-        // Set first round deadline: now + frequency_days converted to seconds
-        let deadline = env.ledger().timestamp() + (frequency_days as u64) * 86_400;
-        env.storage().instance().set(&DataKey::RoundDeadline, &deadline);
-
-        let mut members: Map<Address, MemberData> = Map::new(&env);
-        members.set(
-            organizer.clone(),
-            MemberData {
-                address: organizer.clone(),
-                total_contributed: 0,
-                total_withdrawn: 0,
-                has_received_payout: false,
-                status: 0,
-            },
-        );
-
-        env.storage().instance().set(&DataKey::Members, &members);
-
-        let mut standings: Map<Address, MemberStanding> = Map::new(&env);
-        standings.set(
-            organizer.clone(),
-            MemberStanding {
-                missed_count: 0,
-                is_active: true,
-            },
-        );
-        env.storage().instance().set(&DataKey::Standings, &standings);
-
-        Ok(())
-    }
-
-    /// Join an existing circle as a new member
-    ///
-    /// Adds a new member to the circle. Only the organizer can add members.
-    ///
-    /// # Arguments
-    /// * `env` - Contract environment
-    /// * `organizer` - Address of the circle organizer
-    /// * `new_member` - Address of the member to add
-    ///
-    /// # Returns
-    /// * `Ok(())` on success
-    /// * `Err(AjoError::Unauthorized)` if caller is not the organizer
-    /// * `Err(AjoError::AlreadyExists)` if member already in circle
-    /// * `Err(AjoError::CircleAtCapacity)` if circle is full
-    /// * `Err(AjoError::CirclePanicked)` if circle is in emergency state
-    ///
-    /// # Requirements
-    /// - Caller must be the organizer
-    /// - Member must not already exist
-    /// - Circle must not be at capacity
-    /// - Circle must not be in panic state
-    pub fn join_circle(env: Env, organizer: Address, new_member: Address) -> Result<(), AjoError> {
-        organizer.require_auth();
-
-        // Block joins during panic
-        Self::require_not_paused(&env)?;
-
-        let mut circle: CircleData = env
-            .storage()
-            .instance()
-            .get(&DataKey::Circle)
-            .ok_or(AjoError::NotFound)?;
-
-        if circle.organizer != organizer {
-            return Err(AjoError::Unauthorized);
-        }
-
-        let mut members: Map<Address, MemberData> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Members)
-            .ok_or(AjoError::NotFound)?;
-
-        if members.contains_key(new_member.clone()) {
-            return Err(AjoError::AlreadyExists);
-        }
-
-        if circle.member_count >= circle.max_members {
-            return Err(AjoError::CircleAtCapacity);
-        }
-
-        members.set(
-            new_member.clone(),
-            MemberData {
-                address: new_member.clone(),
-                total_contributed: 0,
-                total_withdrawn: 0,
-                has_received_payout: false,
-                status: 0,
-            },
-        );
-
-        circle.member_count = circle
-            .member_count
-            .checked_add(1)
-            .ok_or(AjoError::InvalidInput)?;
-
-        let mut standings: Map<Address, MemberStanding> = env.storage()
-            .instance()
-            .get(&DataKey::Standings)
-            .unwrap_or(Map::new(&env));
-        
-        standings.set(
-            new_member.clone(),
-            MemberStanding {
-                missed_count: 0,
-                is_active: true,
-            },
-        );
-
-        env.storage().instance().set(&DataKey::Members, &members);
-        env.storage().instance().set(&DataKey::Circle, &circle);
-        env.storage().instance().set(&DataKey::Standings, &standings);
-
-        Ok(())
-    }
-
-    /// Backward-compatible wrapper for joining the circle
-    ///
-    /// Alias for `join_circle` to maintain API compatibility.
-    ///
-    /// # Arguments
-    /// * `env` - Contract environment
-    /// * `organizer` - Address of the circle organizer
-    /// * `new_member` - Address of the member to add
-    ///
-    /// # Returns
-    /// Same as `join_circle`
-    pub fn add_member(env: Env, organizer: Address, new_member: Address) -> Result<(), AjoError> {
-        Self::join_circle(env, organizer, new_member)
-    }
-
-    /// Record a contribution from a member
-    ///
-    /// Allows a member to contribute tokens to the circle. Transfers tokens
-    /// from the member to the contract and updates their contribution balance.
-    ///
-    /// # Arguments
-    /// * `env` - Contract environment
-    /// * `member` - Address of the contributing member
-    /// * `amount` - Amount of tokens to contribute
-    ///
-    /// # Returns
-    /// * `Ok(())` on success
-    /// * `Err(AjoError::InvalidInput)` if amount <= 0
-    /// * `Err(AjoError::NotFound)` if member not in circle
-    /// * `Err(AjoError::Disqualified)` if member is inactive
-    /// * `Err(AjoError::CirclePanicked)` if circle is in emergency state
-    ///
-    /// # Requirements
-    /// - Caller must be the member
-    /// - Amount must be positive
-    /// - Member must be active (not disqualified)
-    /// - Circle must not be in panic state
-    ///
-    /// # Side Effects
-    /// - Resets member's missed contribution count
-    /// - May advance to next round if all members have contributed
-    pub fn contribute(env: Env, member: Address, amount: i128) -> Result<(), AjoError> {
-        member.require_auth();
-
-        if Self::is_paused(&env) {
-    return Err(AjoError::Paused);
-}
-
-        // Block contributions during panic
-
-        if amount <= 0 {
-            return Err(AjoError::InvalidInput);
-        }
-
-        let mut circle: CircleData = env
-            .storage()
-            .instance()
-            .get(&DataKey::Circle)
-            .ok_or(AjoError::NotFound)?;
-
-        let mut standings: Map<Address, MemberStanding> = env.storage()
-            .instance()
-            .get(&DataKey::Standings)
-            .unwrap_or(Map::new(&env));
-
-        if let Some(mut standing) = standings.get(member.clone()) {
-            if standing.missed_count >= 3 {
-                return Err(AjoError::Disqualified);
-            }
-            if !standing.is_active {
-                return Err(AjoError::Disqualified);
-            }
-            // Reset missed count on successful contribution
-            standing.missed_count = 0;
-            standings.set(member.clone(), standing);
-        } else {
-            return Err(AjoError::NotFound);
-        }
-
-        env.storage().instance().set(&DataKey::Standings, &standings);
-
-        let mut members: Map<Address, MemberData> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Members)
-            .ok_or(AjoError::NotFound)?;
-
-        if let Some(mut member_data) = members.get(member.clone()) {
-            let round_target = (circle.current_round as i128)
-                .checked_mul(circle.contribution_amount)
-                .ok_or(AjoError::ArithmeticOverflow)?;
-            let had_completed_round = member_data.total_contributed >= round_target;
-
-            // Transfer tokens from member to contract
-            let token_client = token::Client::new(&env, &circle.token_address);
-            token_client.transfer(&member, &env.current_contract_address(), &amount);
-
-            member_data.total_contributed = member_data
-                .total_contributed
-                .checked_add(amount)
-                .ok_or(AjoError::ArithmeticOverflow)?;
-
-            let has_completed_round = member_data.total_contributed >= round_target;
-
-            members.set(member.clone(), member_data);
-
-            if !had_completed_round && has_completed_round {
-                let mut round_contrib_count: u32 = env
-                    .storage()
-                    .instance()
-                    .get(&DataKey::RoundContribCount)
-                    .unwrap_or(0_u32);
-
-                round_contrib_count = round_contrib_count
-                    .checked_add(1)
-                    .ok_or(AjoError::ArithmeticOverflow)?;
-
-                if round_contrib_count >= circle.member_count {
-                    let deadline: u64 = env
-                        .storage()
-                        .instance()
-                        .get(&DataKey::RoundDeadline)
-                        .unwrap_or(0);
-                    let next_deadline = deadline + (circle.frequency_days as u64) * 86_400;
-                    env.storage().instance().set(&DataKey::RoundDeadline, &next_deadline);
-
-                    if circle.current_round < circle.max_rounds {
-                        circle.current_round += 1;
-                    }
-
-                    round_contrib_count = 0;
-                    env.storage().instance().set(&DataKey::Circle, &circle);
-                }
-
-                env.storage()
-                    .instance()
-                    .set(&DataKey::RoundContribCount, &round_contrib_count);
-            }
-        } else {
-            return Err(AjoError::NotFound);
-        }
-
-        env.storage().instance().set(&DataKey::Members, &members);
-
-        Ok(())
-    }
-
-    /// Deposit exactly the configured periodic contribution amount in the circle token.
-    /// Records the ledger timestamp for the member and increments the tracked pool balance.
-    pub fn deposit(env: Env, member: Address) -> Result<(), AjoError> {
-        member.require_auth();
-
-        if Self::is_paused(&env) {
-    return Err(AjoError::Paused);
-}
-
 
         let circle: CircleData = env
             .storage()
@@ -1204,134 +1045,20 @@ impl AjoCircle {
             .get(&DataKey::Circle)
             .ok_or(AjoError::NotFound)?;
 
-        let amount = circle.contribution_amount;
-        if amount <= 0 {
-            return Err(AjoError::InvalidInput);
-        }
-
-        let mut standings: Map<Address, MemberStanding> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Standings)
-            .unwrap_or(Map::new(&env));
-
-        if let Some(mut standing) = standings.get(member.clone()) {
-            if standing.missed_count >= 3 {
-                return Err(AjoError::Disqualified);
-            }
-            if !standing.is_active {
-                return Err(AjoError::Disqualified);
-            }
-            standing.missed_count = 0;
-            standings.set(member.clone(), standing);
-        } else {
-            return Err(AjoError::NotFound);
-        }
-
-        env.storage().instance().set(&DataKey::Standings, &standings);
-
-        let mut members: Map<Address, MemberData> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Members)
-            .ok_or(AjoError::NotFound)?;
-
-        if let Some(mut member_data) = members.get(member.clone()) {
-            let token_client = token::Client::new(&env, &circle.token_address);
-            token_client.transfer(&member, &env.current_contract_address(), &amount);
-
-            member_data.total_contributed += amount;
-            members.set(member.clone(), member_data);
-        } else {
-            return Err(AjoError::NotFound);
-        }
-
-        let ts = env.ledger().timestamp();
-        let mut last_deposits: Map<Address, u64> = env
-            .storage()
-            .instance()
-            .get(&DataKey::LastDepositAt)
-            .unwrap_or_else(|| Map::new(&env));
-        last_deposits.set(member.clone(), ts);
-        env.storage().instance().set(&DataKey::LastDepositAt, &last_deposits);
-
-        let mut pool: i128 = env.storage().instance().get(&DataKey::TotalPool).unwrap_or(0);
-        pool = pool.checked_add(amount).ok_or(AjoError::InvalidInput)?;
-        env.storage().instance().set(&DataKey::TotalPool, &pool);
-
-        env.storage().instance().set(&DataKey::Members, &members);
-
-        let round_contributions = members
-            .iter()
-            .filter(|(_, m)| {
-                m.total_contributed >= (circle.current_round as i128) * circle.contribution_amount
-            })
-            .count() as u32;
-
-        if round_contributions >= circle.member_count {
-            let deadline: u64 = env
-                .storage()
-                .instance()
-                .get(&DataKey::RoundDeadline)
-                .unwrap_or(0);
-            let next_deadline = deadline + (circle.frequency_days as u64) * 86_400;
-            env.storage()
-                .instance()
-                .set(&DataKey::RoundDeadline, &next_deadline);
-        }
-
-        // Emit DepositReceived event
-        env.events().publish(
-            (symbol_short!("deposit"), member.clone()),
-            (amount, circle.current_round)
-        );
-
-        Ok(())
-    }
-
-    /// Running total of tokens received through `deposit` (tracked in instance storage).
-    pub fn get_total_pool(env: Env) -> i128 {
-        env.storage()
-            .instance()
-            .get(&DataKey::TotalPool)
-            .unwrap_or(0)
-    }
-
-    /// Last `deposit` timestamp for a member, if any.
-    pub fn get_last_deposit_timestamp(env: Env, member: Address) -> Result<u64, AjoError> {
-        let m: Map<Address, u64> = env
-            .storage()
-            .instance()
-            .get(&DataKey::LastDepositAt)
-            .ok_or(AjoError::NotFound)?;
-        m.get(member).ok_or(AjoError::NotFound)
-    }
-
-    /// Shuffle the payout rotation order using ledger sequence as seed (Fisher-Yates).
-    /// Must be called by the organizer before the first round begins.
-    pub fn shuffle_rotation(env: Env, organizer: Address) -> Result<(), AjoError> {
-        organizer.require_auth();
-
-        let circle: CircleData = env.storage()
-            .instance()
-            .get(&DataKey::Circle)
-            .ok_or(AjoError::NotFound)?;
-
         if circle.organizer != organizer {
             return Err(AjoError::Unauthorized);
         }
 
-        // Block shuffle during panic
         Self::require_not_paused(&env)?;
 
-        let members: Map<Address, MemberData> = env.storage()
-            .instance()
-            .get(&DataKey::Members)
-            .ok_or(AjoError::NotFound)?;
+        // Load address list for iteration (only when needed)
+        let member_list = Self::load_member_list(&env);
+        if member_list.is_empty() {
+            return Err(AjoError::NotFound);
+        }
 
-        // Build ordered list from current members
         let mut rotation: Vec<Address> = Vec::new(&env);
-        for (addr, _) in members.iter() {
+        for addr in member_list.iter() {
             rotation.push_back(addr);
         }
 
@@ -1341,18 +1068,15 @@ impl AjoCircle {
             return Ok(());
         }
 
-        // Seed: mix ledger sequence with tx hash bytes for unpredictability
         let ledger_seq = env.ledger().sequence();
         let tx_hash: BytesN<32> = env.crypto().sha256(
             &soroban_sdk::Bytes::from_slice(&env, &ledger_seq.to_be_bytes())
         ).into();
         let hash_bytes = tx_hash.to_array();
 
-        // Fisher-Yates shuffle Ã¢â‚¬â€ seed advances through hash bytes cyclically
         for i in (1..n).rev() {
             let byte_idx = (i as usize) % 32;
             let j = (hash_bytes[byte_idx] as u32) % (i + 1);
-            // Swap rotation[i] and rotation[j]
             let a = rotation.get(i).unwrap();
             let b = rotation.get(j).unwrap();
             rotation.set(i, b);
@@ -1364,29 +1088,22 @@ impl AjoCircle {
         Ok(())
     }
 
-    /// Slash a member for missing a contribution round
+    // ---------------- MEMBER MANAGEMENT ----------------
+
     pub fn slash_member(env: Env, admin: Address, member: Address) -> Result<(), AjoError> {
         Self::require_admin(&env, &admin)?;
 
-        let mut standings: Map<Address, MemberStanding> = env.storage()
-            .instance()
-            .get(&DataKey::Standings)
-            .unwrap_or(Map::new(&env));
-
-        if let Some(mut standing) = standings.get(member.clone()) {
-            standing.missed_count += 1;
-            if standing.missed_count >= 3 {
-                standing.is_active = false;
-            }
-            standings.set(member.clone(), standing);
-            env.storage().instance().set(&DataKey::Standings, &standings);
-            Ok(())
-        } else {
-            Err(AjoError::NotFound)
+        // O(1): load only this member's standing
+        let mut standing = Self::load_standing(&env, &member)?;
+        standing.missed_count += 1;
+        if standing.missed_count >= 3 {
+            standing.is_active = false;
         }
+        Self::save_standing(&env, &member, &standing);
+
+        Ok(())
     }
 
-    /// Update off-chain KYC tie for a member. Admin-only.
     pub fn set_kyc_status(
         env: Env,
         admin: Address,
@@ -1395,28 +1112,18 @@ impl AjoCircle {
     ) -> Result<(), AjoError> {
         Self::require_admin(&env, &admin)?;
 
-        let members_check: Map<Address, MemberData> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Members)
-            .ok_or(AjoError::NotFound)?;
-        if !members_check.contains_key(member.clone()) {
+        // O(1): check membership via per-member key
+        if !Self::member_exists(&env, &member) {
             return Err(AjoError::NotFound);
         }
 
-        let mut kyc: Map<Address, bool> = env
-            .storage()
+        env.storage()
             .instance()
-            .get(&DataKey::KycStatus)
-            .unwrap_or_else(|| Map::new(&env));
-
-        kyc.set(member, is_verified);
-        env.storage().instance().set(&DataKey::KycStatus, &kyc);
+            .set(&DataKey::KycVerified(member), &is_verified);
 
         Ok(())
     }
 
-    /// Remove a dormant user from active standing. Admin-only.
     pub fn boot_dormant_member(
         env: Env,
         admin: Address,
@@ -1424,42 +1131,22 @@ impl AjoCircle {
     ) -> Result<(), AjoError> {
         Self::require_admin(&env, &admin)?;
 
-        let mut standings: Map<Address, MemberStanding> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Standings)
-            .unwrap_or(Map::new(&env));
-
-        if let Some(mut standing) = standings.get(member.clone()) {
-            if standing.is_active && standing.missed_count < 3 {
-                return Err(AjoError::InvalidInput);
-            }
-            standing.is_active = false;
-            standings.set(member.clone(), standing);
-        } else {
-            return Err(AjoError::NotFound);
+        // O(1): load only this member's standing
+        let mut standing = Self::load_standing(&env, &member)?;
+        if standing.is_active && standing.missed_count < 3 {
+            return Err(AjoError::InvalidInput);
         }
+        standing.is_active = false;
+        Self::save_standing(&env, &member, &standing);
 
-        let mut members: Map<Address, MemberData> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Members)
-            .ok_or(AjoError::NotFound)?;
-
-        if let Some(mut member_data) = members.get(member.clone()) {
-            member_data.status = 2;
-            members.set(member, member_data);
-        } else {
-            return Err(AjoError::NotFound);
-        }
-
-        env.storage().instance().set(&DataKey::Standings, &standings);
-        env.storage().instance().set(&DataKey::Members, &members);
+        // O(1): load only this member's data
+        let mut member_data = Self::load_member(&env, &member)?;
+        member_data.status = 2;
+        Self::save_member(&env, &member, &member_data);
 
         Ok(())
     }
 
-    /// Upgrade the contract's WASM code. Restricted to admin.
     pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) -> Result<(), AjoError> {
         Self::require_admin(&env, &admin)?;
         env.deployer().update_current_contract_wasm(new_wasm_hash);


### PR DESCRIPTION
Replace four Map<Address, _> blobs with per-member DataKey variants:
  Member(Address)    — MemberData       O(1) read/write
  Standing(Address)  — MemberStanding   O(1) read/write
  LastDeposit(Address) — u64 timestamp  O(1) read/write
  KycVerified(Address) — bool           O(1) read/write

DataKey::Members now holds Vec<Address> (address list only), loaded exclusively when full iteration is required (shuffle_rotation, deposit round-completion check).

Add private helpers: load_member, save_member, member_exists, load_standing, save_standing, push_member_list, load_member_list.

Remove old blob keys: Standings, LastDepositAt, KycStatus.

All affected functions updated:
  initialize_circle, join_circle, contribute, deposit,
  claim_payout, partial_withdraw, dissolve_and_refund,
  emergency_refund, vote_to_dissolve, slash_member,
  set_kyc_status, boot_dormant_member, get_member_balance,
  get_last_deposit_timestamp, shuffle_rotation

Closes #671