### PR TITLE
fix: Addresses the circles/[id]/join API's duplicate entry issue

### DIFF
--- a/app/api/circles/[id]/join/route.ts
+++ b/app/api/circles/[id]/join/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { verifyToken, extractToken } from '@/lib/auth';
 import { applyRateLimit, validateId } from '@/lib/api-helpers';
@@ -92,14 +93,6 @@ export async function POST(
 
     if (!circle) return NextResponse.json({ error: 'Circle not found' }, { status: 404 });
 
-    const existingMember = await prisma.circleMember.findUnique({
-      where: { circleId_userId: { circleId: id, userId: payload.userId } },
-    });
-
-    if (existingMember) {
-      return NextResponse.json({ error: 'You are already a member of this circle' }, { status: 409 });
-    }
-
     if (circle.status !== 'ACTIVE' && circle.status !== 'PENDING') {
       return NextResponse.json({ error: 'This circle is not accepting new members' }, { status: 403 });
     }
@@ -124,6 +117,9 @@ export async function POST(
 
     return NextResponse.json({ success: true, member: newMember }, { status: 201 });
   } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+      return NextResponse.json({ error: 'You are already a member of this circle' }, { status: 409 });
+    }
     logger.error('Join circle error', { err });
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }


### PR DESCRIPTION
## Summary
I have successfully resolved the duplicate entry issue in the circles/[id]/join API. Here's what was implemented:

### Changes Made:
* Database Constraint Verification: Confirmed that the Prisma schema already includes the required unique constraint:
This ensures no duplicate (userId, circleId) pairs can exist in the database.

* API Code Modifications in route.ts

Added Prisma import: import { Prisma } from '@prisma/client'; to handle database errors properly.

Removed pre-check logic: Eliminated the race-condition prone check for existing membership before attempting to create a new member record.

Enhanced error handling: Modified the catch block to specifically handle PrismaClientKnownRequestErro with code 'P2002' (unique constraint violation), returning a 409 status with the message "You are already a member of this circle".

* How It Works:
When a user clicks the join button rapidly, multiple requests may attempt to create membership records simultaneously.
The database unique constraint prevents duplicate entries at the database level.
If a duplicate is attempted, the constraint violation is caught and handled gracefully in the API.
Users receive a clear error message instead of the operation succeeding multiple times.

* Criteria Met:
✅ A user should never be able to have two active memberships in the same circle - The database constraint ensures this at the data layer, and the API properly handles violation attempts.

The solution follows the exact requirements: adding a unique constraint (already present) and handling the resulting error in the API (now implemented).

Closes #599 